### PR TITLE
Create course PR

### DIFF
--- a/doc/lti.rst
+++ b/doc/lti.rst
@@ -41,8 +41,8 @@ secured using a signature generated using the OAuth 1.0 protocol [OAuth-A] with 
 secret (which should be known only to the tool provider and the tool consumer).
 
 
-Settings for Socraticqs2 LTI provider.
---------------------------------------
+Settings for Socraticqs2 LTI provider
+-------------------------------------
 
 Allow debug information about LTI request
 ::
@@ -74,44 +74,76 @@ Heroku SSL proxy fix
   SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https'))
 
 
-To add new External tool on Moodle LTI consumer we should do the following:
-:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+Adding new External tool on Moodle LTI consumer
+-----------------------------------------------
 
 #. Go to Control Panel of your course
-#. Click on ‘Add an activity or resource’ button
-#. Select ‘External tool’ Activity
+#. Click on ``Add an activity or resource`` button
+#. Select ``External tool`` Activity
 #. Click Add
 #. Click ‘Show more’ on Adding a new External tool page
 #. Type Activity name
-#. Go to Socraticqs2 site
-#. Login as Instructor
-#. Go to course edit page or unit edit page
-#. Copy course or unit URL from ‘Copy course URL’ input field
-#. Paste this URL into ‘Launch URL’ input field on External tool page
-#. Type ‘Consumer key’ and ‘Shared secret’ on External tool page given from our settings_local.py
-#. Click ‘Save and display’ or ‘Save and return to course’
+#. Add ``/lti/`` at the end of Socraticqs2 site URL and specify the resulting URL in form of ``https://socraticqs2_domain_name.org/lti/`` into ``Launch URL`` input field on External tool page
+#. Type ``Consumer key`` and ``Shared secret`` on External tool page given from our settings_local.py
+#. Click ``Save and display`` or ``Save and return to course``
 
 
 LTI user access flow
 --------------------
 
 When LTI user is accessed External Tool we handle LTI request to get all user information from LTI Consumer.
+
 First of all we are verifying LTI request using python port of the useful ims-lti Ruby library.
+
 It can be reviewed there https://github.com/mitodl/ims_lti_py
 
 Next we store LTIUser entry with appropriate LTI params.
 
-Launch LTI request is handled by `lti_init` view.
+Launch LTI request is handled by followed views:
 
-.. automodule:: lti.views
-    :members:
+  .. automodule:: lti.views   
+      :members:
 
 To work with Socraticqs2 courses we need to create/get django user to authorize him and need to have Role objects to have access to courses.
 
 For this requirements we have ``create_links`` and ``enroll`` methods in LTIUser class.
 
-.. autoclass:: lti.models.LTIUser
-    :members:
+  .. autoclass:: lti.models.LTIUser
+      :members:
 
 
-Finally, when Django user logged in and enrolled to course we redirect him to appropriate course given from Resource Link.
+Course creation process
+-----------------------
+
+When Instructor set ``/lti/`` as the LaunchURL for External Tool he can create a blank Course on Socraticqs2 Tool Provider.
+
+**To implement this we follow the next logic:**
+
+
+* First of all, we look at the ``roles`` LTI param to decide whether the user can create courses or not. 
+* Next we look for ``context_id`` LTI param to search our ``CourseRef`` models.
+* That models is a link between Course and particular University identified by ``context_id``.
+
+  .. autoclass:: lti.models.CourseRef
+      :members:
+
+* If we find a ``CourseRef`` entry we just redirect user to a Course.
+* If there is no ``CourseRef`` and user has role ``Instructor`` in ``roles`` LTI param we direct the user to the ``create_courseref`` view:
+
+  .. autofunction:: lti.views.create_courseref
+
+  **That view do the following:**
+
+    * creates a new Course with ``context_title`` title
+    * creates Instructor ``Role`` for a django user with which the LTI user is associated
+    * creates ``CourseRef`` entry to link Tool Consumer with this Course
+    * adds LTI user to Instructor's set of that Course
+    * redirects user to Course edit page
+
+Also we ensure that user is requests for Course creation only from LTI session using ``only_lti`` decorator:
+
+  .. autofunction:: lti.utils.only_lti 
+
+Finally Instructor can change LaunchURL to a ``/lti/unit/{unit_id}/`` pattern to point directly to a particular unit of the Course if he has created one previously.
+
+

--- a/doc/lti.rst
+++ b/doc/lti.rst
@@ -81,9 +81,14 @@ Adding new External tool on Moodle LTI consumer
 #. Click on ``Add an activity or resource`` button
 #. Select ``External tool`` Activity
 #. Click Add
-#. Click ‘Show more’ on Adding a new External tool page
+#. Click ``Show more`` on Adding a new External tool page
 #. Type Activity name
-#. Add ``/lti/`` at the end of Socraticqs2 site URL and specify the resulting URL in form of ``https://socraticqs2_domain_name.org/lti/`` into ``Launch URL`` input field on External tool page
+#. Go to Socraticqs2 site
+#. Login as Instructor
+#. Go to course edit page or unit edit page
+#. Copy course or unit URL from ``Copy course URL`` input field
+#. Paste this URL into ``Launch URL`` input field on External tool page
+#. Alternatively Instructor can create a new empty Course by adding ``/lti/`` at the end of Socraticqs2 site URL and specify the resulting URL in form of ``https://socraticqs2_domain_name.org/lti/`` into ``Launch URL`` input field on External tool page
 #. Type ``Consumer key`` and ``Shared secret`` on External tool page given from our settings_local.py
 #. Click ``Save and display`` or ``Save and return to course``
 

--- a/mysite/lti/admin.py
+++ b/mysite/lti/admin.py
@@ -1,10 +1,16 @@
 from django.contrib import admin
 
-from lti.models import LTIUser
+from lti.models import LTIUser, CourseRef
 
 
 class LTIUserAdmin(admin.ModelAdmin):
     list_display = ('user_id', 'consumer', 'django_user', 'course_id')
 
 
+class CourseRefAdmin(admin.ModelAdmin):
+    list_display = ('context_id', 'course', 'date')
+    filter_horizontal = ('instructors',)
+
+
 admin.site.register(LTIUser, LTIUserAdmin)
+admin.site.register(CourseRef, CourseRefAdmin)

--- a/mysite/lti/admin.py
+++ b/mysite/lti/admin.py
@@ -4,7 +4,7 @@ from lti.models import LTIUser, CourseRef
 
 
 class LTIUserAdmin(admin.ModelAdmin):
-    list_display = ('user_id', 'consumer', 'django_user', 'course_id')
+    list_display = ('user_id', 'consumer', 'django_user', 'context_id')
 
 
 class CourseRefAdmin(admin.ModelAdmin):

--- a/mysite/lti/migrations/0003_auto_20150625_0517.py
+++ b/mysite/lti/migrations/0003_auto_20150625_0517.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.utils.timezone
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('ct', '0014_fsmgroup'),
+        ('lti', '0002_auto_20150429_0310'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CourseRef',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('date', models.DateTimeField(default=django.utils.timezone.now, verbose_name=b'Creation date and time')),
+                ('context_id', models.CharField(max_length=254, verbose_name=b'LTI context_id')),
+                ('tc_guid', models.CharField(max_length=128, verbose_name=b'LTI tool_consumer_instance_guid')),
+                ('course', models.ForeignKey(verbose_name=b'Courslet Course', to='ct.Course')),
+                ('instructors', models.ManyToManyField(to=settings.AUTH_USER_MODEL, verbose_name=b'Course Instructors')),
+            ],
+            options={
+                'verbose_name': 'CourseRef',
+                'verbose_name_plural': 'CourseRefs',
+            },
+            bases=(models.Model,),
+        ),
+        migrations.AlterUniqueTogether(
+            name='courseref',
+            unique_together=set([('context_id', 'course')]),
+        ),
+        migrations.AlterField(
+            model_name='ltiuser',
+            name='course_id',
+            field=models.CharField(max_length=255),
+            preserve_default=True,
+        ),
+    ]

--- a/mysite/lti/migrations/0004_auto_20150716_0259.py
+++ b/mysite/lti/migrations/0004_auto_20150716_0259.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('lti', '0003_auto_20150625_0517'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='ltiuser',
+            old_name='course_id',
+            new_name='context_id',
+        ),
+        migrations.AlterUniqueTogether(
+            name='ltiuser',
+            unique_together=set([('user_id', 'consumer', 'context_id')]),
+        ),
+    ]

--- a/mysite/lti/models.py
+++ b/mysite/lti/models.py
@@ -130,14 +130,15 @@ class LTIUser(models.Model):
 
         :param roles: (str|list)
         :param course_id: int
-        :return: ct.Role
+        :return: bool
         """
         if not isinstance(roles, list):
             roles = roles.split(',')
         course = Course.objects.filter(id=course_id).first()
+        role = Role.INSTRUCTOR if Role.INSTRUCTOR in roles else Role.ENROLLED
         if course:
             return Role.objects.filter(
-                role=roles[0],
+                role=role,
                 course=course,
                 user=self.django_user
             ).exists()

--- a/mysite/lti/models.py
+++ b/mysite/lti/models.py
@@ -1,4 +1,6 @@
 import json
+from django.utils import timezone
+
 from django.db import models
 from django.contrib.auth import login
 from django.contrib.auth.models import User
@@ -31,25 +33,33 @@ class LTIUser(models.Model):
     LTI user params saved to extra_data field::
 
         'user_id'
-        'ext_lms'
+        'context_id'
         'lis_person_name_full'
         'lis_person_name_given'
         'lis_person_name_family'
+        'lis_person_sourcedid'
+        'tool_consumer_instance_guid'
         'lis_person_contact_email_primary'
+        'tool_consumer_info_product_family_code'
     """
     user_id = models.CharField(max_length=255, blank=False)
     consumer = models.CharField(max_length=64, blank=True)
     extra_data = models.TextField(max_length=1024, blank=False)
     django_user = models.ForeignKey(User, null=True, related_name='lti_auth')
-    course_id = models.IntegerField()
+    course_id = models.CharField(max_length=255)
 
     class Meta:  # pragma: no cover
         unique_together = ('user_id', 'consumer', 'course_id')
 
     def create_links(self):
-        """Create all needed links to Django and/or UserSocialAuth"""
+        """
+        Create all needed links to Django and/or UserSocialAuth.
+        """
         extra_data = json.loads(self.extra_data)
-        username = extra_data.get('lis_person_name_full', self.user_id)
+        username = extra_data.get(
+            'lis_person_name_full',
+            extra_data.get('lis_person_sourcedid', self.user_id)
+        )
         first_name = extra_data.get('lis_person_name_given', '')
         last_name = extra_data.get('lis_person_name_family', '')
         email = extra_data.get('lis_person_contact_email_primary', '').lower()
@@ -61,8 +71,9 @@ class LTIUser(models.Model):
 
         if email:
             defaults['email'] = email
-            social = UserSocialAuth.objects.filter(provider='email',
-                                                   uid=email).first()
+            social = UserSocialAuth.objects.filter(
+                provider='email', uid=email
+            ).first()
             if social:
                 django_user = social.user
             else:
@@ -71,19 +82,24 @@ class LTIUser(models.Model):
                     django_user, created = User.objects.get_or_create(
                         username=username, defaults=defaults
                     )
-                social = UserSocialAuth(user=django_user,
-                                        provider='email',
-                                        uid=email,
-                                        extra_data=extra_data)
+                social = UserSocialAuth(
+                    user=django_user,
+                    provider='email',
+                    uid=email,
+                    extra_data=extra_data
+                )
                 social.save()
         else:
-            django_user, created = User.objects.get_or_create(username=username,
-                                                              defaults=defaults)
+            django_user, created = User.objects.get_or_create(
+                username=username, defaults=defaults
+            )
         self.django_user = django_user
         self.save()
 
     def login(self, request):
-        """Login linked Django user"""
+        """
+        Login linked Django user.
+        """
         if self.django_user:
             self.django_user.backend = 'django.contrib.auth.backends.ModelBackend'
             login(request, self.django_user)
@@ -103,9 +119,11 @@ class LTIUser(models.Model):
         course = Course.objects.filter(id=course_id).first()
         if course:
             for role in roles:
-                Role.objects.get_or_create(course=course,
-                                           user=self.django_user,
-                                           role=role)
+                Role.objects.get_or_create(
+                    role=role,
+                    course=course,
+                    user=self.django_user
+                )
 
     def is_enrolled(self, roles, course_id):
         """Check enroll status
@@ -118,9 +136,11 @@ class LTIUser(models.Model):
             roles = roles.split(',')
         course = Course.objects.filter(id=course_id).first()
         if course:
-            return Role.objects.filter(course=course,
-                                       user=self.django_user,
-                                       role=roles[0]).exists()
+            return Role.objects.filter(
+                role=roles[0],
+                course=course,
+                user=self.django_user
+            ).exists()
 
     @property
     def is_linked(self):
@@ -129,3 +149,32 @@ class LTIUser(models.Model):
         :return: bool
         """
         return bool(self.django_user)
+
+
+class CourseRef(models.Model):  # pragma: no cover
+    """Course reference
+
+    Represent Course reference with meta information
+    such as::
+
+        course -> Courslet Course entry
+        instructors -> list of User entry
+        date - > creation date
+        context_id -> LTI context_id
+        tc_guid - > LTI tool_consumer_instance_guid
+    """
+    course = models.ForeignKey(Course, verbose_name='Courslet Course')
+    instructors = models.ManyToManyField(User, verbose_name='Course Instructors')
+    date = models.DateTimeField('Creation date and time', default=timezone.now)
+    context_id = models.CharField('LTI context_id', max_length=254)
+    tc_guid = models.CharField('LTI tool_consumer_instance_guid', max_length=128)
+
+    class Meta:
+        verbose_name = "CourseRef"
+        verbose_name_plural = "CourseRefs"
+        unique_together = ('context_id', 'course')
+
+    def __str__(self):
+        return '{0} {1}'.format(
+            self.course.title, str(self.date.strftime('%H:%M %d-%m-%y'))
+        )

--- a/mysite/lti/models.py
+++ b/mysite/lti/models.py
@@ -27,8 +27,8 @@ class LTIUser(models.Model):
       .. attribute:: django_user
       Django user to store study progress
 
-      .. attribute:: course_id
-      Course entry id given from Launch URL
+      .. attribute:: context_id
+      Context id given from LTI params
 
     LTI user params saved to extra_data field::
 
@@ -46,10 +46,10 @@ class LTIUser(models.Model):
     consumer = models.CharField(max_length=64, blank=True)
     extra_data = models.TextField(max_length=1024, blank=False)
     django_user = models.ForeignKey(User, null=True, related_name='lti_auth')
-    course_id = models.CharField(max_length=255)
+    context_id = models.CharField(max_length=255)
 
     class Meta:  # pragma: no cover
-        unique_together = ('user_id', 'consumer', 'course_id')
+        unique_together = ('user_id', 'consumer', 'context_id')
 
     def create_links(self):
         """
@@ -135,7 +135,10 @@ class LTIUser(models.Model):
         if not isinstance(roles, list):
             roles = roles.split(',')
         course = Course.objects.filter(id=course_id).first()
-        role = Role.INSTRUCTOR if Role.INSTRUCTOR in roles else Role.ENROLLED
+        if Role.INSTRUCTOR in roles:
+            role = Role.INSTRUCTOR
+        else:
+            role = Role.ENROLLED
         if course:
             return Role.objects.filter(
                 role=role,

--- a/mysite/lti/tests.py
+++ b/mysite/lti/tests.py
@@ -297,7 +297,7 @@ class TestCourseRef(LTITestCase):
                     'roles': 'Instructor'}
         request = Mock()
         request.user = self.user
-        request.session = {'LTI_POST': json.dumps(lti_post),
+        request.session = {'LTI_POST': lti_post,
                            'is_valid': True}
         res = create_courseref(request)
         self.assertEqual(res.url, reverse(langing_page, args=(_id,)))

--- a/mysite/lti/tests.py
+++ b/mysite/lti/tests.py
@@ -120,7 +120,7 @@ class ParamsTest(LTITestCase):
 
     @unpack
     @data((Role.INSTRUCTOR, {u'roles': u'Instructor'}),
-          (Role.ENROLLED, {u'roles': u'Leaner'}))
+          (Role.ENROLLED, {u'roles': u'Learner'}))
     def test_roles(self, role, header, mocked):
         self.headers.update(header)
         mocked.return_value.is_valid_request.return_value = True
@@ -277,7 +277,7 @@ class TestCourseRef(LTITestCase):
 
     def test_create_courseref_only_lti(self, mocked):
         """
-        Test that only LTI is assowed.
+        Test that only LTI is allowed.
         """
         request = Mock()
         request.session = {}

--- a/mysite/lti/tests.py
+++ b/mysite/lti/tests.py
@@ -273,7 +273,7 @@ class TestCourseRef(LTITestCase):
         self.course_ref.delete()
         response = self.client.post('/lti/', data=self.headers, follow=True)
         self.assertFalse(CourseRef.objects.filter(course=self.course).exists())
-        self.assertTemplateUsed(response, 'ct/index.html')
+        self.assertTemplateUsed(response, 'lti/error.html')
 
     def test_create_courseref_only_lti(self, mocked):
         """

--- a/mysite/lti/tests.py
+++ b/mysite/lti/tests.py
@@ -285,11 +285,12 @@ class TestCourseRef(LTITestCase):
         self.assertEqual(res.content, 'Only LTI allowed')
 
     @unpack
-    @data(('1', 1), ('1111', 2))
-    def test_create_courseref_existence(self, context_id, _id, mocked):
+    @data(('1', 'ct:course'), ('1111', 'ct:edit_course'))
+    def test_create_courseref_existence(self, context_id, langing_page, mocked):
         """
         Test for existence/non-existence of CourseRef.
         """
+        _id = self.course.id if context_id == '1' else self.course.id + 1
         lti_post = {'context_id': context_id,
                     'context_title': 'test title',
                     'tool_consumer_instance_guid': 'test.dot.com',
@@ -299,7 +300,7 @@ class TestCourseRef(LTITestCase):
         request.session = {'LTI_POST': json.dumps(lti_post),
                            'is_valid': True}
         res = create_courseref(request)
-        self.assertEqual(res.url, reverse('ct:edit_course', args=(_id,)))
+        self.assertEqual(res.url, reverse(langing_page, args=(_id,)))
 
 
 @patch('lti.views.DjangoToolProvider')
@@ -310,6 +311,6 @@ class TestUnit(LTITestCase):
     def test_unit_render(self, mocked):
         mocked.return_value.is_valid_request.return_value = True
         response = self.client.post(
-            '/lti/unit/1/', data=self.headers, follow=True
+            '/lti/unit/{}/'.format(self.unit.id), data=self.headers, follow=True
         )
         self.assertTemplateUsed(response, 'ct/study_unit.html')

--- a/mysite/lti/tests.py
+++ b/mysite/lti/tests.py
@@ -237,7 +237,7 @@ class ModelTest(LTITestCase):
                            consumer='test_consumer',
                            extra_data=json.dumps(self.headers),
                            django_user=self.user,
-                           course_id=self.course.id)
+                           context_id=1)
         lti_user.save()
 
         self.assertFalse(lti_user.is_enrolled('student', self.course.id))
@@ -253,7 +253,7 @@ class ModelTest(LTITestCase):
         lti_user = LTIUser(user_id=self.user.id,
                            consumer='test_consumer',
                            extra_data=json.dumps(self.headers),
-                           course_id=self.course.id)
+                           context_id=1)
         lti_user.save()
 
         self.assertFalse(lti_user.is_linked)

--- a/mysite/lti/tests.py
+++ b/mysite/lti/tests.py
@@ -2,24 +2,26 @@
 
 import json
 import oauth2
-from mock import patch
+
+from mock import patch, Mock
+from ddt import ddt, data, unpack
 from django.test import TestCase, Client
 from django.contrib.auth.models import User
-from ddt import ddt, data, unpack
+from django.core.urlresolvers import reverse
 
-from lti.models import LTIUser
-from ct.models import Course, Role
 from psa.models import UserSocialAuth
+from ct.models import Course, Role, Unit, CourseUnit
+from lti.models import LTIUser, CourseRef
+from lti.views import create_courseref
 
 
 class LTITestCase(TestCase):
     def setUp(self):
-        """Preconditions."""
+        """
+        Preconditions.
+        """
         self.client = Client()
-
-        self.user = User(username='test_user',
-                         email='test@test.com')
-        self.user.save()
+        self.user = User.objects.create_user('test', 'test@test.com', 'test')
 
         mocked_nonce = u'135685044251684026041377608307'
         mocked_timestamp = u'1234567890'
@@ -30,13 +32,16 @@ class LTITestCase(TestCase):
             u'lis_person_name_given': u'First',
             u'lis_person_name_family': u'Second',
             u'lis_person_contact_email_primary': u'test@test.com',
+            u'lis_person_sourcedid': u'Test_Username',
             u'oauth_callback': u'about:blank',
             u'launch_presentation_return_url': '',
             u'lti_message_type': u'basic-lti-launch-request',
             u'lti_version': 'LTI-1p0',
             u'roles': u'Student',
             u'context_id': 1,
-            u'ext_lms': u'moodle-2',
+            u'tool_consumer_info_product_family_code': u'moodle',
+            u'context_title': u'Test title',
+            u'tool_consumer_instance_guid': u'test.dot.com',
 
             u'resource_link_id': 'dfgsfhrybvrth',
             u'lis_result_sourcedid': 'wesgaegagrreg',
@@ -49,34 +54,51 @@ class LTITestCase(TestCase):
             u'oauth_signature': mocked_decoded_signature
         }
 
-        self.course = Course(title='test title',
+        self.unit = Unit(title='Test title', addedBy=self.user)
+        self.unit.save()
+        self.course = Course(title='Test title',
                              description='test description',
                              access='Public',
+                             enrollCode='111',
+                             lockout='222',
                              addedBy=self.user)
         self.course.save()
+        self.course_ref = CourseRef(
+            course=self.course, context_id=self.headers.get('context_id'),
+            tc_guid=self.headers.get('tool_consumer_instance_guid')
+        )
+        self.course_ref.save()
+        self.course_ref.instructors.add(self.user)
+
+        self.courseunit = CourseUnit(
+            unit=self.unit, course=self.course,
+            order=0, addedBy=self.user
+        )
+        self.courseunit.save()
 
 
 @patch('lti.views.DjangoToolProvider')
 class MethodsTest(LTITestCase):
-    """Test for correct request method passed in view."""
-
+    """
+    Test for correct request method passed in view.
+    """
     def test_post(self, mocked):
         mocked.return_value.is_valid_request.return_value = True
-        response = self.client.post('/lti/ct/courses/{}/'.format(self.course.id),
+        response = self.client.post('/lti/',
                                     data=self.headers,
                                     follow=True)
         self.assertTemplateUsed(response, template_name='ct/course.html')
 
     def test_failure_post(self, mocked):
         mocked.return_value.is_valid_request.return_value = False
-        response = self.client.post('/lti/ct/courses/{}/'.format(self.course.id),
+        response = self.client.post('/lti/',
                                     data=self.headers,
                                     follow=True)
         self.assertTemplateUsed(response, template_name='lti/error.html')
 
     def test_get(self, mocked):
         mocked.return_value.is_valid_request.return_value = True
-        response = self.client.get('/lti/ct/courses/{}/'.format(self.course.id),
+        response = self.client.get('/lti/',
                                    follow=True)
         self.assertTemplateUsed(response, template_name='lti/error.html')
 
@@ -84,23 +106,25 @@ class MethodsTest(LTITestCase):
 @ddt
 @patch('lti.views.DjangoToolProvider')
 class ParamsTest(LTITestCase):
-    """Test different params handling."""
+    """
+    Test different params handling.
+    """
 
-    def test_ext_lms(self, mocked):
-        del self.headers[u'ext_lms']
+    def test_tool_consumer_info_product_family_code(self, mocked):
+        del self.headers[u'tool_consumer_info_product_family_code']
         mocked.return_value.is_valid_request.return_value = True
-        self.client.post('/lti/ct/courses/{}/'.format(self.course.id),
+        self.client.post('/lti/',
                          data=self.headers,
                          follow=True)
         self.assertTrue(LTIUser.objects.filter(consumer='lti').exists())
 
     @unpack
-    @data(('prof', {u'roles': u'Instructor'}),
-          ('student', {u'roles': u'Leaner'}))
+    @data((Role.INSTRUCTOR, {u'roles': u'Instructor'}),
+          (Role.ENROLLED, {u'roles': u'Leaner'}))
     def test_roles(self, role, header, mocked):
         self.headers.update(header)
         mocked.return_value.is_valid_request.return_value = True
-        self.client.post('/lti/ct/courses/{}/'.format(self.course.id),
+        self.client.post('/lti/',
                          data=self.headers,
                          follow=True)
         self.assertTrue(Role.objects.filter(role=role).exists())
@@ -108,7 +132,7 @@ class ParamsTest(LTITestCase):
     def test_user_id(self, mocked):
         del self.headers[u'user_id']
         mocked.return_value.is_valid_request.return_value = True
-        response = self.client.post('/lti/ct/courses/{}/'.format(self.course.id),
+        response = self.client.post('/lti/',
                                     data=self.headers,
                                     follow=True)
         self.assertTemplateUsed(response, template_name='lti/error.html')
@@ -116,20 +140,22 @@ class ParamsTest(LTITestCase):
     def test_roles_none(self, mocked):
         del self.headers[u'roles']
         mocked.return_value.is_valid_request.return_value = True
-        self.client.post('/lti/ct/courses/{}/'.format(self.course.id),
+        self.client.post('/lti/',
                          data=self.headers,
                          follow=True)
-        self.assertTrue(Role.objects.filter(role='student').exists())
+        self.assertTrue(Role.objects.filter(role=Role.ENROLLED).exists())
 
     def test_lti_user(self, mocked):
-        """Default LTI user creation process"""
+        """
+        Default LTI user creation process.
+        """
         mocked.return_value.is_valid_request.return_value = True
-        self.client.post('/lti/ct/courses/{}/'.format(self.course.id),
+        self.client.post('/lti/',
                          data=self.headers,
                          follow=True)
-        self.assertTrue(LTIUser.objects.filter(consumer='moodle-2').exists())
-        self.assertTrue(Role.objects.filter(role='student').exists())
-        self.assertEqual(LTIUser.objects.get(consumer='moodle-2').django_user,
+        self.assertTrue(LTIUser.objects.filter(consumer='moodle').exists())
+        self.assertTrue(Role.objects.filter(role=Role.ENROLLED).exists())
+        self.assertEqual(LTIUser.objects.get(consumer='moodle').django_user,
                          UserSocialAuth.objects.get(
                              uid=self.headers[u'lis_person_contact_email_primary']
                          ).user)
@@ -140,12 +166,12 @@ class ParamsTest(LTITestCase):
     def test_lti_user_no_email(self, mocked):
         del self.headers[u'lis_person_contact_email_primary']
         mocked.return_value.is_valid_request.return_value = True
-        self.client.post('/lti/ct/courses/{}/'.format(self.course.id),
+        self.client.post('/lti/',
                          data=self.headers,
                          follow=True)
-        self.assertTrue(LTIUser.objects.filter(consumer='moodle-2').exists())
-        self.assertTrue(Role.objects.filter(role='student').exists())
-        self.assertNotEqual(LTIUser.objects.get(consumer='moodle-2').django_user,
+        self.assertTrue(LTIUser.objects.filter(consumer='moodle').exists())
+        self.assertTrue(Role.objects.filter(role=Role.ENROLLED).exists())
+        self.assertNotEqual(LTIUser.objects.get(consumer='moodle').django_user,
                             User.objects.get(id=self.user.id))
 
     def test_lti_user_no_username_no_email(self, mocked):
@@ -157,19 +183,21 @@ class ParamsTest(LTITestCase):
         del self.headers[u'lis_person_name_full']
         del self.headers[u'lis_person_contact_email_primary']
         mocked.return_value.is_valid_request.return_value = True
-        self.client.post('/lti/ct/courses/{}/'.format(self.course.id),
+        self.client.post('/lti/',
                          data=self.headers,
                          follow=True)
-        self.assertTrue(LTIUser.objects.filter(consumer='moodle-2').exists())
-        self.assertTrue(Role.objects.filter(role='student').exists())
-        self.assertNotEqual(LTIUser.objects.get(consumer='moodle-2').django_user,
+        self.assertTrue(LTIUser.objects.filter(consumer='moodle').exists())
+        self.assertTrue(Role.objects.filter(role=Role.ENROLLED).exists())
+        self.assertNotEqual(LTIUser.objects.get(consumer='moodle').django_user,
                             User.objects.get(id=self.user.id))
-        self.assertEqual(LTIUser.objects.get(consumer='moodle-2').
+        self.assertEqual(LTIUser.objects.get(consumer='moodle').
                          django_user.username,
-                         LTIUser.objects.get(consumer='moodle-2').user_id)
+                         self.headers.get('lis_person_sourcedid'))
 
     def test_lti_user_link_social(self, mocked):
-        """Default LTI user creation process"""
+        """
+        Default LTI user creation process.
+        """
         social = UserSocialAuth(
             user=self.user,
             uid=self.headers[u'lis_person_contact_email_primary'],
@@ -177,34 +205,36 @@ class ParamsTest(LTITestCase):
         )
         social.save()
         mocked.return_value.is_valid_request.return_value = True
-        self.client.post('/lti/ct/courses/{}/'.format(self.course.id),
+        self.client.post('/lti/',
                          data=self.headers,
                          follow=True)
-        self.assertTrue(LTIUser.objects.filter(consumer='moodle-2').exists())
-        self.assertTrue(Role.objects.filter(role='student').exists())
-        self.assertEqual(LTIUser.objects.get(consumer='moodle-2').django_user,
+        self.assertTrue(LTIUser.objects.filter(consumer='moodle').exists())
+        self.assertTrue(Role.objects.filter(role=Role.ENROLLED).exists())
+        self.assertEqual(LTIUser.objects.get(consumer='moodle').django_user,
                          social.user)
 
 
 @ddt
 @patch('lti.views.DjangoToolProvider')
 class ExceptionTest(LTITestCase):
-    """Test raising exception."""
-
+    """
+    Test raising exception.
+    """
     @data(oauth2.MissingSignature, oauth2.Error, KeyError, AttributeError)
     def test_exceptions(self, exception, mocked):
         mocked.return_value.is_valid_request.side_effect = exception()
-        response = self.client.get('/lti/ct/courses/{}/'.format(self.course.id), follow=True)
+        response = self.client.get('/lti/', follow=True)
         self.assertTemplateUsed(response, template_name='lti/error.html')
 
 
 class ModelTest(LTITestCase):
-    """Test model LTIUser."""
-
+    """
+    Test model LTIUser.
+    """
     def test_lti_user(self):
         """Test enrollment process"""
         lti_user = LTIUser(user_id=self.user.id,
-                           consumer='test_consimer',
+                           consumer='test_consumer',
                            extra_data=json.dumps(self.headers),
                            django_user=self.user,
                            course_id=self.course.id)
@@ -221,7 +251,7 @@ class ModelTest(LTITestCase):
         Testing Django user creation process.
         """
         lti_user = LTIUser(user_id=self.user.id,
-                           consumer='test_consimer',
+                           consumer='test_consumer',
                            extra_data=json.dumps(self.headers),
                            course_id=self.course.id)
         lti_user.save()
@@ -229,3 +259,57 @@ class ModelTest(LTITestCase):
         self.assertFalse(lti_user.is_linked)
         lti_user.create_links()
         self.assertTrue(lti_user.is_linked)
+
+
+@ddt
+@patch('lti.views.DjangoToolProvider')
+class TestCourseRef(LTITestCase):
+    """
+    Testing CourseRef object.
+    """
+    def test_course_ref_roles(self, mocked):
+        """Test different action for different roles"""
+        mocked.return_value.is_valid_request.return_value = True
+        self.course_ref.delete()
+        response = self.client.post('/lti/', data=self.headers, follow=True)
+        self.assertFalse(CourseRef.objects.filter(course=self.course).exists())
+        self.assertTemplateUsed(response, 'ct/index.html')
+
+    def test_create_courseref_only_lti(self, mocked):
+        """
+        Test that only LTI is assowed.
+        """
+        request = Mock()
+        request.session = {}
+        res = create_courseref(request)
+        self.assertEqual(res.content, 'Only LTI allowed')
+
+    @unpack
+    @data(('1', 1), ('1111', 2))
+    def test_create_courseref_existence(self, context_id, _id, mocked):
+        """
+        Test for existence/non-existence of CourseRef.
+        """
+        lti_post = {'context_id': context_id,
+                    'context_title': 'test title',
+                    'tool_consumer_instance_guid': 'test.dot.com',
+                    'roles': 'Instructor'}
+        request = Mock()
+        request.user = self.user
+        request.session = {'LTI_POST': json.dumps(lti_post),
+                           'is_valid': True}
+        res = create_courseref(request)
+        self.assertEqual(res.url, reverse('ct:edit_course', args=(_id,)))
+
+
+@patch('lti.views.DjangoToolProvider')
+class TestUnit(LTITestCase):
+    """
+    Testing Unit template rendering.
+    """
+    def test_unit_render(self, mocked):
+        mocked.return_value.is_valid_request.return_value = True
+        response = self.client.post(
+            '/lti/unit/1/', data=self.headers, follow=True
+        )
+        self.assertTemplateUsed(response, 'ct/study_unit.html')

--- a/mysite/lti/urls.py
+++ b/mysite/lti/urls.py
@@ -1,8 +1,10 @@
 from django.conf.urls import url, patterns
 
+from lti.views import create_courseref
+
 
 urlpatterns = patterns(
     '',
-    url(r'^ct/courses/(?P<course_id>\d+)/$', 'lti.views.lti_init', name='lti_init'),
-    url(r'^ct/courses/(?P<course_id>\d+)/units/(?P<unit_id>\d+)/$', 'lti.views.lti_init', name='lti_init'),
+    url(r'(^$|^unit/(?P<unit_id>\d+)/$)', 'lti.views.lti_init', name='lti_init'),
+    url(r'^create_courseref/$', create_courseref, name='create_courseref'),
 )

--- a/mysite/lti/urls.py
+++ b/mysite/lti/urls.py
@@ -5,6 +5,16 @@ from lti.views import create_courseref
 
 urlpatterns = patterns(
     '',
+    url(
+        r'^ct/courses/(?P<course_id>\d+)/units/(?P<unit_id>\d+)/$',
+        'lti.views.lti_init',
+        name='lti_init_course_directly_with_unit'
+    ),
+    url(
+        r'^ct/courses/(?P<course_id>\d+)/$',
+        'lti.views.lti_init',
+        name='lti_init_course_directly'
+    ),
     url(r'(^$|^unit/(?P<unit_id>\d+)/$)', 'lti.views.lti_init', name='lti_init'),
     url(r'^create_courseref/$', create_courseref, name='create_courseref'),
 )

--- a/mysite/lti/utils.py
+++ b/mysite/lti/utils.py
@@ -1,7 +1,13 @@
+from functools import wraps
+
 from django.http import HttpResponse
 
 
 def only_lti(fn):
+    """
+    Decorator ensures that user comes from LTI session.
+    """
+    @wraps(fn)
     def wrapped(request, *args, **kwargs):
         try:
             request.session['LTI_POST']

--- a/mysite/lti/utils.py
+++ b/mysite/lti/utils.py
@@ -1,0 +1,12 @@
+from django.http import HttpResponse
+
+
+def only_lti(fn):
+    def wrapped(request, *args, **kwargs):
+        try:
+            request.session['LTI_POST']
+        except KeyError:
+            return HttpResponse(content=b'Only LTI allowed')
+        else:
+            return fn(request, *args, **kwargs)
+    return wrapped

--- a/mysite/lti/views.py
+++ b/mysite/lti/views.py
@@ -63,7 +63,7 @@ def lti_init(request, course_id=None, unit_id=None):
         session['message'] = "{}".format(err)
 
     session['is_valid'] = is_valid
-    session['LTI_POST'] = json.dumps({k: v for (k, v) in request.POST.iteritems()})
+    session['LTI_POST'] = {k: v for (k, v) in request.POST.iteritems()}
 
     if settings.LTI_DEBUG:
         msg = 'session: is_valid = {}'.format(session.get('is_valid'))
@@ -90,7 +90,7 @@ def lti_redirect(request, course_id=None, unit_id=None):
 
     :param unit_id: unit id from lunch url
     """
-    request_dict = json.loads(request.session['LTI_POST'])
+    request_dict = request.session['LTI_POST']
 
     context_id = request_dict.get('context_id')
     course_ref = CourseRef.objects.filter(context_id=context_id).first()
@@ -156,7 +156,7 @@ def create_courseref(request):
     """
     Create CourseRef and Course entry based on context_title.
     """
-    request_dict = json.loads(request.session['LTI_POST'])
+    request_dict = request.session['LTI_POST']
     if not request.session.get('is_valid'):
         return redirect(reverse('ct:home'))
     context_id = request_dict.get('context_id')

--- a/mysite/lti/views.py
+++ b/mysite/lti/views.py
@@ -1,4 +1,3 @@
-import pickle
 import oauth2
 import json
 import logging
@@ -8,34 +7,38 @@ from django.views.decorators.csrf import csrf_exempt
 from ims_lti_py.tool_provider import DjangoToolProvider
 from django.shortcuts import render_to_response, redirect
 
-from lti.models import LTIUser
+from lti.utils import only_lti
 from lti import app_settings as settings
+from lti.models import LTIUser, CourseRef
+from ct.models import Course, Role
 
 
 ROLES_MAP = {
-    'Instructor': 'prof',
-    'Learner': 'student',
+    'Instructor': Role.INSTRUCTOR,
+    'Learner': Role.ENROLLED,
 }
 
 MOODLE_PARAMS = (
     'user_id',
-    'ext_lms',
+    'context_id',
     'lis_person_name_full',
     'lis_person_name_given',
     'lis_person_name_family',
+    'lis_person_sourcedid',
+    'tool_consumer_instance_guid',
     'lis_person_contact_email_primary',
+    'tool_consumer_info_product_family_code',
 )
 
 LOGGER = logging.getLogger('lti_debug')
 
 
 @csrf_exempt
-def lti_init(request, course_id=None, unit_id=None):
+def lti_init(request, unit_id=None):
     """LTI init view
 
     Analyze LTI POST request to start LTI session.
 
-    :param course_id: course id from launch url
     :param unit_id: unit id from lunch url
     """
     if settings.LTI_DEBUG:
@@ -59,7 +62,7 @@ def lti_init(request, course_id=None, unit_id=None):
         session['message'] = "{}".format(err)
 
     session['is_valid'] = is_valid
-    session['LTI_POST'] = pickle.dumps({k: v for (k, v) in request.POST.iteritems()})
+    session['LTI_POST'] = json.dumps({k: v for (k, v) in request.POST.iteritems()})
 
     if settings.LTI_DEBUG:
         msg = 'session: is_valid = {}'.format(session.get('is_valid'))
@@ -70,30 +73,34 @@ def lti_init(request, course_id=None, unit_id=None):
     if not is_valid:
         return render_to_response('lti/error.html', RequestContext(request))
 
-    return lti_redirect(request, course_id, unit_id)
+    return lti_redirect(request, unit_id)
 
 
-def lti_redirect(request, course_id=None, unit_id=None):
+def lti_redirect(request, unit_id=None):
     """Create user and redirect to Course
 
     |  Create LTIUser with all needed link to Django user
     |  and/or UserSocialAuth.
     |  Finally login Django user and redirect to Course
 
-    :param course_id: course id from launch url
     :param unit_id: unit id from lunch url
     """
-    request_dict = pickle.loads(request.session['LTI_POST'])
-    consumer_name = request_dict.get('ext_lms', 'lti')
-    user_id = request_dict.get('user_id', None)
-    roles = ROLES_MAP.get(request_dict.get('roles', None), 'student')
-    if not user_id or not course_id:
-        return render_to_response('lti/error.html', RequestContext(request))
-    course_id = int(course_id)
+    request_dict = json.loads(request.session['LTI_POST'])
 
-    user, created = LTIUser.objects.get_or_create(user_id=user_id,
-                                                  consumer=consumer_name,
-                                                  course_id=course_id)
+    context_id = request_dict.get('context_id')
+    course_ref = CourseRef.objects.filter(context_id=context_id).first()
+    consumer_name = request_dict.get('tool_consumer_info_product_family_code', 'lti')
+    user_id = request_dict.get('user_id', None)
+    roles = ROLES_MAP.get(request_dict.get('roles', None), Role.ENROLLED)
+
+    if not user_id:
+        return render_to_response('lti/error.html', RequestContext(request))
+
+    user, created = LTIUser.objects.get_or_create(
+        user_id=user_id,
+        consumer=consumer_name,
+        course_id=request_dict.get('context_id')
+    )
     extra_data = {k: v for (k, v) in request_dict.iteritems()
                   if k in MOODLE_PARAMS}
     user.extra_data = json.dumps(extra_data)
@@ -101,21 +108,65 @@ def lti_redirect(request, course_id=None, unit_id=None):
 
     if not user.is_linked:
         user.create_links()
-
     user.login(request)
+
+    if course_ref:
+        course_id = course_ref.course.id
+    elif Role.INSTRUCTOR in roles:
+        return redirect(reverse('lti:create_courseref'))
+    else:
+        return redirect(reverse('ct:home'))
+
     user.enroll(roles, course_id)
 
     if user.is_enrolled(roles, course_id):
         # Redirect to course or unit page considering users role
         if not unit_id:
             dispatch = 'ct:course_student'
-            if roles == 'prof':
+            if roles == Role.INSTRUCTOR:
                 dispatch = 'ct:course'
             return redirect(reverse(dispatch, args=(course_id,)))
         else:
             dispatch = 'ct:study_unit'
-            if roles == 'prof':
+            if roles == Role.INSTRUCTOR:
                 dispatch = 'ct:unit_tasks'
             return redirect(reverse(dispatch, args=(course_id, unit_id)))
     else:
         return redirect(reverse('ct:home'))
+
+
+@only_lti
+def create_courseref(request):
+    """
+    Create CourseRef and Course entry based on context_title.
+    """
+    request_dict = json.loads(request.session['LTI_POST'])
+    if not request.session.get('is_valid'):
+        return redirect(reverse('ct:home'))
+    context_id = request_dict.get('context_id')
+    role = ROLES_MAP.get(request_dict.get('roles', None), Role.ENROLLED)
+    # Make sure this context_id is not used
+    course_ref = CourseRef.objects.filter(context_id=context_id).first()
+    if course_ref:
+        if role == Role.INSTRUCTOR:
+            return redirect(reverse('ct:edit_course', args=(course_ref.course.id,)))
+        else:
+            return redirect(reverse('ct:home'))
+
+    course = Course(
+        title=request_dict.get('context_title', 'Course title for %s' % context_id),
+        addedBy=request.user
+    )
+    course.save()
+    role = Role(role=Role.INSTRUCTOR, course=course, user=request.user)
+    role.save()
+    course_id = course.id
+    course_ref = CourseRef(
+        course=course,
+        context_id=context_id,
+        tc_guid=request_dict.get('tool_consumer_instance_guid', request.META.get('HTTP_HOST'))
+    )
+    course_ref.save()
+    course_ref.instructors.add(request.user)
+
+    return redirect(reverse('ct:edit_course', args=(course_id,)))

--- a/mysite/lti/views.py
+++ b/mysite/lti/views.py
@@ -39,6 +39,7 @@ def lti_init(request, course_id=None, unit_id=None):
 
     Analyze LTI POST request to start LTI session.
 
+    :param course_id: course id from launch url
     :param unit_id: unit id from lunch url
     """
     if settings.LTI_DEBUG:
@@ -108,7 +109,7 @@ def lti_redirect(request, course_id=None, unit_id=None):
     user, created = LTIUser.objects.get_or_create(
         user_id=user_id,
         consumer=consumer_name,
-        course_id=request_dict.get('context_id')
+        context_id=request_dict.get('context_id')
     )
     extra_data = {k: v for (k, v) in request_dict.iteritems()
                   if k in MOODLE_PARAMS}
@@ -165,7 +166,7 @@ def create_courseref(request):
     course_ref = CourseRef.objects.filter(context_id=context_id).first()
     if course_ref:
         if Role.INSTRUCTOR in roles:
-            return redirect(reverse('ct:edit_course', args=(course_ref.course.id,)))
+            return redirect(reverse('ct:course', args=(course_ref.course.id,)))
         else:
             return redirect(reverse('ct:home'))
 

--- a/mysite/mysite/urls.py
+++ b/mysite/mysite/urls.py
@@ -6,7 +6,8 @@ from mysite.views import *
 from django.contrib import admin
 admin.autodiscover()
 
-urlpatterns = patterns('',
+urlpatterns = patterns(
+    '',
     (r'^$', home_page),
     # Examples:
     # url(r'^$', 'mysite.views.home', name='home'),
@@ -34,11 +35,10 @@ urlpatterns = patterns('',
     url(r'^set-pass/$', 'psa.views.set_pass'),
 
     url(r'^done/$', 'psa.views.done'),
-    
-
 )
 
 if apps.is_installed('lti'):
-    urlpatterns += patterns('',
-        url(r'^lti/', include('lti.urls')),
+    urlpatterns += patterns(
+        '',
+        url(r'^lti/', include('lti.urls', namespace='lti')),
     )

--- a/mysite/templates/lti/error.html
+++ b/mysite/templates/lti/error.html
@@ -1,9 +1,12 @@
-<html>
-<head>
-    <title>IMS LTI Error</title>
-</head>
-<body>
-Error
-{{ message }}
-</body>
-</html>
+{% extends "ct/portal.html" %}
+
+
+{% block content %}
+
+    <div class="alert alert-danger" role="alert">
+      <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+      <span class="sr-only">Error:</span>
+      {{ message }}
+    </div>
+
+{% endblock %}


### PR DESCRIPTION
@cjlee112 

This PR added create Course feature.

Course creation feature
=======================

Tool Consumer Instructor's can create Courses on Socraticqs2 Tool Provider remotely.

For this purpose it is necessary to enter `/lti/` url as `LaunchURL` on Tool Consumer External Tool edit page.

This PR added ability to handle such url's by looking at LTI request for `context_id`, `context_title`, `tool_consumer_instance_guid` and `roles` parameters.

To implement this we follow the next logic:
 * First of all, we look at the `roles` LTI param of the user to decide whether the user can create courses or not.
 * Next we look for `context_id` LTI param to search our CourseRef models. That models is a link between Course and particular University identified by ``context_id``.
 * If we find a CourseRef entry we just redirect user to a Course.
 * If there is no CourseRef and user has role `Instructor` in `roles` LTI param we direct user to the `create_courseref` view.

That view do the following:
  * creates a new Course with ``context_title`` title
  * creates Instructor ``Role`` for a django user with which the LTI user is associated
  * creates ``CourseRef`` entry to link Tool Consumer with this Course
  * adds LTI user to Instructor's set of that Course
  * redirects user to Course edit page

Also we ensure that user requests for Course creation only from LTI session.
Finally Instructor can change `LaunchURL` to a `/lti/unit/{unit_id}/` pattern to point directly to a particular unit of the Course if he has created one previously.


Update for @cjlee112 
I have fixed @auraz code review questions and you can continue this PR code review.

This PR resolve #49