### PR TITLE
ref(fsm): add db indexes to fields by which filtering are performed

### DIFF
--- a/mysite/fsm/migrations/0002_auto_20150723_0243.py
+++ b/mysite/fsm/migrations/0002_auto_20150723_0243.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('fsm', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='fsmedge',
+            name='name',
+            field=models.CharField(max_length=64, db_index=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='fsmgroup',
+            name='group',
+            field=models.CharField(max_length=64, db_index=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='fsmnode',
+            name='name',
+            field=models.CharField(max_length=64, db_index=True),
+            preserve_default=True,
+        ),
+    ]

--- a/mysite/fsm/models.py
+++ b/mysite/fsm/models.py
@@ -224,7 +224,7 @@ class FSMGroup(models.Model):
     Groups multiple FSMs into one named UI group.
     """
     fsm = models.ForeignKey(FSM)
-    group = models.CharField(max_length=64)
+    group = models.CharField(db_index=True, max_length=64)
 
 
 class PluginDescriptor(object):
@@ -250,7 +250,7 @@ class FSMNode(JSONBlobMixin, models.Model):
     Stores one node of an FSM state-graph.
     """
     fsm = models.ForeignKey(FSM)
-    name = models.CharField(max_length=64)
+    name = models.CharField(db_index=True, max_length=64)
     title = models.CharField(max_length=200)
     description = models.TextField(null=True)
     help = models.TextField(null=True)
@@ -329,7 +329,7 @@ class FSMEdge(JSONBlobMixin, models.Model):
     """
     Stores one edge of an FSM state-graph.
     """
-    name = models.CharField(max_length=64)
+    name = models.CharField(db_index=True, max_length=64)
     fromNode = models.ForeignKey(FSMNode, related_name='outgoing')
     toNode = models.ForeignKey(FSMNode, related_name='incoming')
     title = models.CharField(max_length=200)


### PR DESCRIPTION
@cjlee112 

PR to  add db indexes to fields by which filtering are performed


Rationalize:
- FSMGroup.group: index added due to `FSM.objects.filter(fsmgroup__group=groupName)` in ct/views.py:203
- FSMNode.name: index added due to `self.fsmnode_set.get(name=name)` in fsm/models.py:219
- FSMEdge.name: index added due to `self.fsmNode.outgoing.get(name=name)` in fsm/models.py:419 and `pageData.fsmStack.state.fsmNode.outgoing.filter(name=task)` in fsm/views.py:68


Issue https://github.com/cjlee112/socraticqs2/issues/58
Task on [trello](https://trello.com/c/Neg8vRQs/170-fsm-add-db-indexes).
