### PR TITLE
Add getsentry config and raven app

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -55,3 +55,7 @@ sqlparse==0.1.15
 python-memcached==1.54
 psycopg2==2.6.1
 Fabric==1.10.2
+
+
+# getsentry
+raven

--- a/mysite/mysite/settings/defaults.py
+++ b/mysite/mysite/settings/defaults.py
@@ -125,6 +125,7 @@ WSGI_APPLICATION = 'mysite.wsgi.application'
 
 
 INSTALLED_APPS = (
+    'raven.contrib.django.raven_compat',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',

--- a/mysite/mysite/settings/local_conf_example.py
+++ b/mysite/mysite/settings/local_conf_example.py
@@ -41,3 +41,9 @@ GOOGLE_ANALYTICS_CODE = ""
 
 if 'test' in sys.argv or 'test_coverage' in sys.argv:
     DATABASES['default']['ENGINE'] = 'django.db.backends.sqlite3'
+
+# GetSentry config
+
+RAVEN_CONFIG = {
+    'dsn': '',
+}

--- a/prod_requirements.txt
+++ b/prod_requirements.txt
@@ -40,3 +40,6 @@ Fabric==1.10.2
 
 # deployment packages
 gunicorn==19.3.0
+
+# getsentry
+raven

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,3 +52,6 @@ sqlparse==0.1.15
 python-memcached==1.54
 psycopg2==2.6.1
 Fabric==1.10.2
+
+# getsentry
+raven


### PR DESCRIPTION
@cjlee112 @VladimirFilonov 

If pricing plan of getsentry (https://getsentry.com/pricing/) is acceptable you can approve this PR.
To finish integration you need to create getsentry account and set account `dsn` (https://app.getsentry.com/account_name/local-dev-courselets/settings/install/) setting into `local_conf.py`