### PR TITLE
Course report API

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -55,3 +55,4 @@ sqlparse==0.1.15
 python-memcached==1.54
 psycopg2==2.6.1
 Fabric==1.10.2
+djangorestframework==3.3.1

--- a/mysite/ct/api.py
+++ b/mysite/ct/api.py
@@ -1,0 +1,19 @@
+from rest_framework import viewsets
+
+from ct.serializers import ResponseSerializer
+from ct.models import Response
+
+
+class ResponseViewSet(viewsets.mixins.ListModelMixin, viewsets.GenericViewSet):
+    """
+    Django RestFramework class to implement Course report.
+    """
+    queryset = Response.objects.filter(kind='orct', unitLesson__order__isnull=False)
+    serializer_class = ResponseSerializer
+
+    def get_queryset(self):
+        queryset = super(ResponseViewSet, self).get_queryset()
+        course_id = self.kwargs.get('course_id')
+        if course_id:
+            queryset = queryset.filter(course__id=course_id)
+        return queryset

--- a/mysite/ct/api.py
+++ b/mysite/ct/api.py
@@ -1,13 +1,17 @@
 from rest_framework import viewsets
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.permissions import IsAdminUser
 
-from ct.serializers import ResponseSerializer
-from ct.models import Response
+from ct.serializers import ResponseSerializer, ErrorSerializer
+from ct.models import Response, StudentError
 
 
 class ResponseViewSet(viewsets.mixins.ListModelMixin, viewsets.GenericViewSet):
     """
-    Django RestFramework class to implement Course report.
+    Django RestFramework class to implement Course student responses report.
     """
+    authentication_classes = (SessionAuthentication,)
+    permission_classes = (IsAdminUser,)
     queryset = Response.objects.filter(kind='orct', unitLesson__order__isnull=False)
     serializer_class = ResponseSerializer
 
@@ -16,4 +20,21 @@ class ResponseViewSet(viewsets.mixins.ListModelMixin, viewsets.GenericViewSet):
         course_id = self.kwargs.get('course_id')
         if course_id:
             queryset = queryset.filter(course__id=course_id)
+        return queryset
+
+
+class ErrorViewSet(viewsets.mixins.ListModelMixin, viewsets.GenericViewSet):
+    """
+    Django RestFramework class to implement Course student errors report.
+    """
+    authentication_classes = (SessionAuthentication,)
+    permission_classes = (IsAdminUser,)
+    queryset = StudentError.objects.all()
+    serializer_class = ErrorSerializer
+
+    def get_queryset(self):
+        queryset = super(ErrorViewSet, self).get_queryset()
+        course_id = self.kwargs.get('course_id')
+        if course_id:
+            queryset = queryset.filter(response__course__id=course_id)
         return queryset

--- a/mysite/ct/serializers.py
+++ b/mysite/ct/serializers.py
@@ -1,0 +1,50 @@
+from rest_framework import serializers
+
+from ct.models import Response
+
+
+class ResponseSerializer(serializers.HyperlinkedModelSerializer):
+    get_author_id = serializers.SerializerMethodField('author_id')
+    get_lti_identity = serializers.SerializerMethodField('lti_identity')
+    get_unitLesson_id = serializers.SerializerMethodField('unitLesson_id')
+    get_unit_id = serializers.SerializerMethodField('unit_id')
+
+    class Meta:
+        model = Response
+        fields = (
+            'id',
+            'get_author_id',
+            'get_lti_identity',
+            'text',
+            'confidence',
+            'selfeval',
+            'status',
+            'get_unitLesson_id',
+            'get_unit_id'
+        )
+
+    def author_id(self, obj):
+        """
+        Returning author id.
+        """
+        return obj.author.id
+
+    def lti_identity(self, obj):
+        """
+        Returning LTI user_id.
+        """
+        lti_user = obj.author.lti_auth.first()
+        if lti_user:
+            return lti_user.user_id
+
+    def unitLesson_id(self, obj):
+        """
+        Returning UnitLesson id.
+        """
+        return obj.unitLesson.id
+
+    def unit_id(self, obj):
+        """
+        Returning Unit id.
+        """
+        return obj.unitLesson.unit.id

--- a/mysite/ct/serializers.py
+++ b/mysite/ct/serializers.py
@@ -1,13 +1,13 @@
 from rest_framework import serializers
 
-from ct.models import Response
+from ct.models import Response, StudentError, UnitLesson
 
 
-class ResponseSerializer(serializers.HyperlinkedModelSerializer):
-    author_id = serializers.SerializerMethodField()
+class ResponseSerializer(serializers.ModelSerializer):
+    author_id = serializers.IntegerField()
     author_name = serializers.SerializerMethodField()
     lti_identity = serializers.SerializerMethodField()
-    unitLesson_id = serializers.SerializerMethodField()
+    unitLesson_id = serializers.IntegerField()
     unit_id = serializers.SerializerMethodField()
 
     class Meta:
@@ -24,12 +24,6 @@ class ResponseSerializer(serializers.HyperlinkedModelSerializer):
             'unitLesson_id',
             'unit_id',
         )
-
-    def get_author_id(self, obj):
-        """
-        Returning author id.
-        """
-        return obj.author.id
 
     def get_author_name(self, obj):
         """
@@ -48,14 +42,63 @@ class ResponseSerializer(serializers.HyperlinkedModelSerializer):
         if lti_user:
             return lti_user.user_id
 
-    def get_unitLesson_id(self, obj):
-        """
-        Returning UnitLesson id.
-        """
-        return obj.unitLesson.id
-
     def get_unit_id(self, obj):
         """
         Returning Unit id.
         """
         return obj.unitLesson.unit.id
+
+
+class UnitLessonSerializer(serializers.ModelSerializer):
+    """
+    UnitLesson serializer for ErrorSerializer.
+    """
+    lesson_concept_id = serializers.SerializerMethodField()
+    lesson_concept_isAbort = serializers.SerializerMethodField()
+    lesson_concept_isFail = serializers.SerializerMethodField()
+    lesson_text = serializers.SerializerMethodField()
+
+    class Meta:
+        model = UnitLesson
+        fields = (
+            'id',
+            'lesson_concept_id',
+            'lesson_concept_isAbort',
+            'lesson_concept_isFail',
+            'lesson_text',
+            'treeID',
+        )
+
+    def get_lesson_concept_id(self, obj):
+        return obj.lesson.concept.id
+
+    def get_lesson_concept_isAbort(self, obj):
+        return obj.lesson.concept.isAbort
+
+    def get_lesson_concept_isFail(self, obj):
+        return obj.lesson.concept.isFail
+
+    def get_lesson_text(self, obj):
+        return obj.lesson.text
+
+
+class ErrorSerializer(serializers.ModelSerializer):
+    response_id = serializers.IntegerField()
+    author_id = serializers.IntegerField()
+    errorModel_id = serializers.IntegerField()
+    em_data = serializers.SerializerMethodField()
+
+    class Meta:
+        model = StudentError
+        fields = (
+            'id',
+            'response_id',
+            'status',
+            'atime',
+            'author_id',
+            'errorModel_id',
+            'em_data',
+        )
+
+    def get_em_data(self, obj):
+        return UnitLessonSerializer().to_representation(obj.errorModel)

--- a/mysite/ct/serializers.py
+++ b/mysite/ct/serializers.py
@@ -4,32 +4,32 @@ from ct.models import Response
 
 
 class ResponseSerializer(serializers.HyperlinkedModelSerializer):
-    get_author_id = serializers.SerializerMethodField('author_id')
-    get_lti_identity = serializers.SerializerMethodField('lti_identity')
-    get_unitLesson_id = serializers.SerializerMethodField('unitLesson_id')
-    get_unit_id = serializers.SerializerMethodField('unit_id')
+    author_id = serializers.SerializerMethodField()
+    lti_identity = serializers.SerializerMethodField()
+    unitLesson_id = serializers.SerializerMethodField()
+    unit_id = serializers.SerializerMethodField()
 
     class Meta:
         model = Response
         fields = (
             'id',
-            'get_author_id',
-            'get_lti_identity',
+            'author_id',
+            'lti_identity',
             'text',
             'confidence',
             'selfeval',
             'status',
-            'get_unitLesson_id',
-            'get_unit_id'
+            'unitLesson_id',
+            'unit_id',
         )
 
-    def author_id(self, obj):
+    def get_author_id(self, obj):
         """
         Returning author id.
         """
         return obj.author.id
 
-    def lti_identity(self, obj):
+    def get_lti_identity(self, obj):
         """
         Returning LTI user_id.
         """
@@ -37,13 +37,13 @@ class ResponseSerializer(serializers.HyperlinkedModelSerializer):
         if lti_user:
             return lti_user.user_id
 
-    def unitLesson_id(self, obj):
+    def get_unitLesson_id(self, obj):
         """
         Returning UnitLesson id.
         """
         return obj.unitLesson.id
 
-    def unit_id(self, obj):
+    def get_unit_id(self, obj):
         """
         Returning Unit id.
         """

--- a/mysite/ct/serializers.py
+++ b/mysite/ct/serializers.py
@@ -5,6 +5,7 @@ from ct.models import Response
 
 class ResponseSerializer(serializers.HyperlinkedModelSerializer):
     author_id = serializers.SerializerMethodField()
+    author_name = serializers.SerializerMethodField()
     lti_identity = serializers.SerializerMethodField()
     unitLesson_id = serializers.SerializerMethodField()
     unit_id = serializers.SerializerMethodField()
@@ -14,6 +15,7 @@ class ResponseSerializer(serializers.HyperlinkedModelSerializer):
         fields = (
             'id',
             'author_id',
+            'author_name',
             'lti_identity',
             'text',
             'confidence',
@@ -28,6 +30,15 @@ class ResponseSerializer(serializers.HyperlinkedModelSerializer):
         Returning author id.
         """
         return obj.author.id
+
+    def get_author_name(self, obj):
+        """
+        Returning author name.
+        """
+        name = obj.author.get_full_name()
+        if not name:
+            name = obj.author.username
+        return name
 
     def get_lti_identity(self, obj):
         """

--- a/mysite/ct/urls.py
+++ b/mysite/ct/urls.py
@@ -1,5 +1,11 @@
 from django.conf.urls import patterns, include, url
+from rest_framework import routers
+
 from ct.views import *
+
+
+router = routers.DefaultRouter()
+router.register(r'course-report', ResponseViewSet)
 
 urlpatterns = patterns('',
     url(r'^$', main_page, name='home'),
@@ -136,4 +142,5 @@ urlpatterns = patterns('',
     url(r'^courses/$', courses, name='courses'),
     # Subscribe to course with particular id
     url(r'^courses/(?P<course_id>\d+)/subscribe/$', courses_subscribe, name='subscribe'),
+    url(r'^', include(router.urls)),
 )

--- a/mysite/ct/urls.py
+++ b/mysite/ct/urls.py
@@ -5,7 +5,7 @@ from ct.views import *
 
 
 router = routers.DefaultRouter()
-router.register(r'course-report', ResponseViewSet)
+router.register(r'report', ResponseViewSet)
 
 urlpatterns = patterns('',
     url(r'^$', main_page, name='home'),
@@ -142,5 +142,6 @@ urlpatterns = patterns('',
     url(r'^courses/$', courses, name='courses'),
     # Subscribe to course with particular id
     url(r'^courses/(?P<course_id>\d+)/subscribe/$', courses_subscribe, name='subscribe'),
+    url(r'^report/(?P<course_id>\d+)/$', ResponseViewSet.as_view({'get': 'list'}), name='report'),
     url(r'^', include(router.urls)),
 )

--- a/mysite/ct/urls.py
+++ b/mysite/ct/urls.py
@@ -5,7 +5,7 @@ from ct.views import *
 
 
 router = routers.DefaultRouter()
-router.register(r'report', ResponseViewSet)
+router.register(r'courses/report', ResponseViewSet)
 
 urlpatterns = patterns('',
     url(r'^$', main_page, name='home'),
@@ -142,6 +142,6 @@ urlpatterns = patterns('',
     url(r'^courses/$', courses, name='courses'),
     # Subscribe to course with particular id
     url(r'^courses/(?P<course_id>\d+)/subscribe/$', courses_subscribe, name='subscribe'),
-    url(r'^report/(?P<course_id>\d+)/$', ResponseViewSet.as_view({'get': 'list'}), name='report'),
+    url(r'^courses/(?P<course_id>\d+)/report/$', ResponseViewSet.as_view({'get': 'list'}), name='report'),
     url(r'^', include(router.urls)),
 )

--- a/mysite/ct/urls.py
+++ b/mysite/ct/urls.py
@@ -1,11 +1,7 @@
 from django.conf.urls import patterns, include, url
-from rest_framework import routers
 
 from ct.views import *
 
-
-router = routers.DefaultRouter()
-router.register(r'courses/report', ResponseViewSet)
 
 urlpatterns = patterns('',
     url(r'^$', main_page, name='home'),
@@ -142,6 +138,4 @@ urlpatterns = patterns('',
     url(r'^courses/$', courses, name='courses'),
     # Subscribe to course with particular id
     url(r'^courses/(?P<course_id>\d+)/subscribe/$', courses_subscribe, name='subscribe'),
-    url(r'^courses/(?P<course_id>\d+)/report/$', ResponseViewSet.as_view({'get': 'list'}), name='report'),
-    url(r'^', include(router.urls)),
 )

--- a/mysite/ct/views.py
+++ b/mysite/ct/views.py
@@ -14,7 +14,6 @@ from django.shortcuts import render, get_object_or_404
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseRedirect, HttpResponse
 from social.backends.utils import load_backends
-from rest_framework import viewsets
 
 from ct.forms import *
 from ct.models import *
@@ -27,7 +26,6 @@ from ct.templatetags.ct_extras import (md2html,
                                        get_path_type)
 from fsm.fsm_base import FSMStack
 from fsm.models import FSM, FSMState, KLASS_NAME_DICT
-from ct.serializers import ResponseSerializer
 
 
 ###########################################################
@@ -1554,18 +1552,3 @@ def assess_errors(request, course_id, unit_id, ul_id, resp_id):
     return pageData.render(request, 'ct/assess.html',
                 dict(response=r, answer=answer, errorModels=allErrors,
                      showAnswer=False))
-
-
-class ResponseViewSet(viewsets.mixins.ListModelMixin, viewsets.GenericViewSet):
-    """
-    Django RestFramework clas to implement Course report.
-    """
-    queryset = Response.objects.filter(kind='orct', unitLesson__order__isnull=False)
-    serializer_class = ResponseSerializer
-
-    def get_queryset(self):
-        queryset = super(ResponseViewSet, self).get_queryset()
-        course_id = self.kwargs.get('course_id')
-        if course_id:
-            queryset = queryset.filter(course__id=course_id)
-        return queryset

--- a/mysite/ct/views.py
+++ b/mysite/ct/views.py
@@ -14,6 +14,7 @@ from django.shortcuts import render, get_object_or_404
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseRedirect, HttpResponse
 from social.backends.utils import load_backends
+from rest_framework import viewsets
 
 from ct.forms import *
 from ct.models import *
@@ -26,6 +27,7 @@ from ct.templatetags.ct_extras import (md2html,
                                        get_path_type)
 from fsm.fsm_base import FSMStack
 from fsm.models import FSM, FSMState, KLASS_NAME_DICT
+from ct.serializers import ResponseSerializer
 
 
 ###########################################################
@@ -1552,3 +1554,11 @@ def assess_errors(request, course_id, unit_id, ul_id, resp_id):
     return pageData.render(request, 'ct/assess.html',
                 dict(response=r, answer=answer, errorModels=allErrors,
                      showAnswer=False))
+
+
+class ResponseViewSet(viewsets.mixins.ListModelMixin, viewsets.GenericViewSet):
+    """
+    Django RestFramework clas to implement Course report.
+    """
+    queryset = Response.objects.filter(kind='orct', unitLesson__order__isnull=False).all()
+    serializer_class = ResponseSerializer

--- a/mysite/ct/views.py
+++ b/mysite/ct/views.py
@@ -1560,5 +1560,12 @@ class ResponseViewSet(viewsets.mixins.ListModelMixin, viewsets.GenericViewSet):
     """
     Django RestFramework clas to implement Course report.
     """
-    queryset = Response.objects.filter(kind='orct', unitLesson__order__isnull=False).all()
+    queryset = Response.objects.filter(kind='orct', unitLesson__order__isnull=False)
     serializer_class = ResponseSerializer
+
+    def get_queryset(self):
+        queryset = super(ResponseViewSet, self).get_queryset()
+        course_id = self.kwargs.get('course_id')
+        if course_id:
+            queryset = queryset.filter(course__id=course_id)
+        return queryset

--- a/mysite/mysite/settings/defaults.py
+++ b/mysite/mysite/settings/defaults.py
@@ -143,6 +143,7 @@ INSTALLED_APPS = (
     # Socials
     'social.apps.django_app.default',
     'psa',
+    'rest_framework',
 )
 
 CRISPY_TEMPLATE_PACK = 'bootstrap3'

--- a/mysite/mysite/urls.py
+++ b/mysite/mysite/urls.py
@@ -1,10 +1,16 @@
 from django.conf.urls import patterns, include, url
 from django.apps import apps
+from rest_framework import routers
+
 from mysite.views import *
+from ct.api import ResponseViewSet
 
 # Uncomment the next two lines to enable the admin:
 from django.contrib import admin
 admin.autodiscover()
+
+router = routers.DefaultRouter()
+router.register(r'api/courses/responses', ResponseViewSet)
 
 urlpatterns = patterns(
     '',
@@ -35,6 +41,9 @@ urlpatterns = patterns(
     url(r'^set-pass/$', 'psa.views.set_pass'),
 
     url(r'^done/$', 'psa.views.done'),
+
+    url(r'^api/courses/(?P<course_id>\d+)/responses/$', ResponseViewSet.as_view({'get': 'list'}), name='responses'),
+    url(r'^', include(router.urls)),
 )
 
 if apps.is_installed('lti'):

--- a/mysite/mysite/urls.py
+++ b/mysite/mysite/urls.py
@@ -3,7 +3,7 @@ from django.apps import apps
 from rest_framework import routers
 
 from mysite.views import *
-from ct.api import ResponseViewSet
+from ct.api import ResponseViewSet, ErrorViewSet
 
 # Uncomment the next two lines to enable the admin:
 from django.contrib import admin
@@ -11,6 +11,7 @@ admin.autodiscover()
 
 router = routers.DefaultRouter()
 router.register(r'api/courses/responses', ResponseViewSet)
+router.register(r'api/courses/errors', ErrorViewSet)
 
 urlpatterns = patterns(
     '',
@@ -43,6 +44,7 @@ urlpatterns = patterns(
     url(r'^done/$', 'psa.views.done'),
 
     url(r'^api/courses/(?P<course_id>\d+)/responses/$', ResponseViewSet.as_view({'get': 'list'}), name='responses'),
+    url(r'^api/courses/(?P<course_id>\d+)/errors/$', ErrorViewSet.as_view({'get': 'list'}), name='errors'),
     url(r'^', include(router.urls)),
 )
 

--- a/prod_requirements.txt
+++ b/prod_requirements.txt
@@ -40,3 +40,5 @@ Fabric==1.10.2
 
 # deployment packages
 gunicorn==19.3.0
+
+djangorestframework==3.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,3 +52,4 @@ sqlparse==0.1.15
 python-memcached==1.54
 psycopg2==2.6.1
 Fabric==1.10.2
+djangorestframework==3.3.1


### PR DESCRIPTION
@cjlee112 @VladimirFilonov 

This PR adds Course report functionality as REST API using Django rest framework.

It can be tested on following links:
`https://dev.courselets.org/api/courses/1/responses/` => Course `id=1` report
`https://dev.courselets.org/api/courses/responses/` => All Courses report

Additional question I want to ask is about LTI identity - currently I add `LTIUser.user_id` as `lti_identity` field.

What identity you want? I can add DjangoUser `username` or `lis_person_name_full` or `lis_person_sourcedid`. So if you want some `id` to be added to results - there are Django user `id` as `author_id` or LTIUser `user_id` as `lti_identity`. If you want some readable name to be added - I can add DjangoUser `username` and LTIUser `some_name_from_lti`.