### PR TITLE
chore(python-social-auth): update library version to `0.2.21`

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -50,7 +50,7 @@ pypandoc==0.9.7
 python-openid==2.2.5
 
 # social authentication/registration mechanizm
-python-social-auth==0.2.12
+python-social-auth==0.2.21
 
 pytz==2015.2
 requests==2.7.0

--- a/mysite/psa/migrations/0003_auto_20150420_0308.py
+++ b/mysite/psa/migrations/0003_auto_20150420_0308.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('email', models.EmailField(max_length=75, verbose_name=b'Secondary Email')),
-                ('provider', models.ForeignKey(to='default.UserSocialAuth')),
+                ('provider', models.ForeignKey(to='social_auth.UserSocialAuth')),
                 ('user', models.ForeignKey(related_name='secondary', to=settings.AUTH_USER_MODEL)),
             ],
             options={

--- a/mysite/psa/migrations/0004_customcode.py
+++ b/mysite/psa/migrations/0004_customcode.py
@@ -17,11 +17,11 @@ class Migration(migrations.Migration):
             fields=[
                 ('code_ptr', models.OneToOneField(
                     parent_link=True, auto_created=True, primary_key=True,
-                    serialize=False, to='default.Code')),
+                    serialize=False, to='social_auth.Code')),
                 ('user_id', models.IntegerField(null=True)),
             ],
             options={
             },
-            bases=('default.code',),
+            bases=('social_auth.code',),
         ),
     ]

--- a/prod_requirements.txt
+++ b/prod_requirements.txt
@@ -26,7 +26,7 @@ pypandoc==0.9.7
 python-openid==2.2.5
 
 # social authentication/registration mechanizm
-python-social-auth==0.2.12
+python-social-auth==0.2.21
 
 pytz==2015.2
 requests==2.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ pypandoc==0.9.7
 python-openid==2.2.5
 
 # social authentication/registration mechanizm
-python-social-auth==0.2.12
+python-social-auth==0.2.21
 
 pytz==2015.2
 requests==2.7.0


### PR DESCRIPTION
Changes:
- change ForeignKey in `psa` application to look on `social_auth` instead of `default` `python-social-auth default Django app` (issue #993)