### PR TITLE
fix(issue#199): prevent sending data to the server when user hitting Enter

### DIFF
--- a/mysite/lms/static/js/presenters/cui.chat-presenter.js
+++ b/mysite/lms/static/js/presenters/cui.chat-presenter.js
@@ -1029,9 +1029,9 @@ CUI.ChatPresenter.prototype._addEventListeners = function(){
     this._postText();
   }, this)).on('keyup', $.proxy(function(e){
     // Submit form on enter but ignore if ctrl, alt or shift is pressed
-    if(e.which == 13 && (!e.shiftKey && !e.ctrlKey && !e.altKey)) {
+    if(e.which == 13) {
       e.preventDefault();
-      this._$inputContainer.find('#chat-input-text-form').submit();
+//      this._$inputContainer.find('#chat-input-text-form').submit();
     }
   }, this));
 


### PR DESCRIPTION
fix(ChatUI): prevent sending data to the server when user hitting Enter button in Chat UI.

Now, user can send messages only manually clicking on button Submit.
TODO: should we somehow specifically handle hitting on enter? (eg add \n into the message or so)