### PR TITLE
fix(issue#378): When user move unitLesson we have to drop out linked ConceptLinks

### DIFF
--- a/mysite/ct/tests/views.py
+++ b/mysite/ct/tests/views.py
@@ -991,6 +991,7 @@ class EditLessonTest(TestCase):
         unit = Unit.objects.create(title='test unit 2 title', addedBy=self.user)
         course_unit2 = CourseUnit(course=self.course, unit=unit, order=0, addedBy=self.user)
         course_unit2.save()
+        self.assertEqual(self.unit_lesson.lesson.conceptlink_set.count(), 1)
         response = self.client.post(
             reverse(
                 'ct:edit_lesson',

--- a/mysite/ct/tests/views.py
+++ b/mysite/ct/tests/views.py
@@ -987,6 +987,22 @@ class EditLessonTest(TestCase):
         self.assertIn('addForm', response.context)
         self.assertIn('roleForm', response.context)
 
+    def test_edit_lesson_move_ul(self):
+        unit = Unit.objects.create(title='test unit 2 title', addedBy=self.user)
+        course_unit2 = CourseUnit(course=self.course, unit=unit, order=0, addedBy=self.user)
+        course_unit2.save()
+        response = self.client.post(
+            reverse(
+                'ct:edit_lesson',
+                kwargs={'course_id': self.course.id, 'unit_id': self.unit.id, 'ul_id': self.unit_lesson.id}
+            ),
+            {'unit_to_move': course_unit2.id},
+            follow=True
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'ct/edit_lesson.html')
+        self.assertFalse(len(self.unit_lesson.lesson.conceptlink_set.all()))
+
     def test_edit_lesson_delete(self):
         response = self.client.post(
             reverse(

--- a/mysite/ct/views.py
+++ b/mysite/ct/views.py
@@ -1119,6 +1119,7 @@ def edit_lesson(request, course_id, unit_id, ul_id):
                 if unit_to_move:
                     ul.order = None
                     ul.unit = unit_to_move
+                    ul.lesson.conceptlink_set.all().delete()
                     unit_to_move.append(ul, ul.addedBy)
                     unit.reorder_exercise()
                     return HttpResponseRedirect(reverse(


### PR DESCRIPTION
When user move unitLesson form one courselet to another one we have to remove all concept links which are linked to moved unit lesson

Issue #378 
