### PR TITLE
fix(issue#434): Fixed linking dummy concepts with UL, lessons...

### DIFF
--- a/mysite/ctms/views.py
+++ b/mysite/ctms/views.py
@@ -632,7 +632,6 @@ class AddUnitEditView(NewLoginRequiredMixin, CourseCoursletUnitMixin, FormSetBas
         if not ul.lesson.concept:
             ul.lesson.concept = dummy_concept
             ul.lesson.addedBy = self.request.user
-            ul.lesson.save_root(dummy_concept, Lesson.ERROR_MODEL)
         for err_form in formset:
             if err_form.is_valid() and err_form.cleaned_data:
                 error_models.append(err_form.save(ul, self.request.user))


### PR DESCRIPTION
fix(issue#434): Fixed linking dummy concepts with UL, lessons and other needed things.

Removed ul.save_root before saving error model. When we save ErrorModel it will save all objects.