### PR TITLE
fix(sidebar_middleware): Fixed logic related to remembering Course/Courselet/Unit ids in sidebar MW

### DIFF
--- a/mysite/ctms/middleware.py
+++ b/mysite/ctms/middleware.py
@@ -174,14 +174,17 @@ class SideBarMiddleware(SideBarUtils):
                 old_id = old_obj_ids.get(cls.__name__)
                 new_id = model_ids.get(cls)
                 if old_id and new_id:
-                    if new_id != old_id:
-                        obj_ids[cls.__name__] = new_id
-                    else:
-                        obj_ids[cls.__name__] = new_id
+                    # replace old_id with new
+                    obj_ids[cls.__name__] = new_id
                 elif old_id and not new_id:
+                    # remember old id
                     obj_ids[cls.__name__] = old_id
                 elif not old_id and new_id:
+                    # remember new id
                     obj_ids[cls.__name__] = new_id
+                else:
+                    # safely remove this id from dict
+                    obj_ids.pop(cls.__name__, None)
             request.session['sidebar_object_ids'] = obj_ids
         return None
 

--- a/mysite/ctms/views.py
+++ b/mysite/ctms/views.py
@@ -813,7 +813,8 @@ class RedirectToCourseletPreviewView(NewLoginRequiredMixin, CourseCoursletUnitMi
                 is_preview=True
             )
 
-        return redirect('chat:preview_courselet', **{'enroll_key': enroll.enrollCode})
+            return redirect('chat:preview_courselet', **{'enroll_key': enroll.enrollCode})
+        raise Http404()
 
 
 class RedirectToAddUnitsView(NewLoginRequiredMixin, CourseCoursletUnitMixin, View):

--- a/mysite/templates/ctms/includes/sidebar.html
+++ b/mysite/templates/ctms/includes/sidebar.html
@@ -135,7 +135,7 @@
                 {% for unit in sidebar.courslet_units %}
                   <!-- TODO: add <a class="sidebar__units__active" ... for the active unit -->
                   <li>
-                    <a href="{% url 'ctms:unit_view' course_pk=sidebar.course.id courslet_pk=sidebar.courslet.id pk=unit.id %}" class="{% if sidebar.unit == unit %}sidebar__units__active{% endif %}">
+                    <a href="{% url 'ctms:unit_view' course_pk=sidebar.courslet.course.id courslet_pk=sidebar.courslet.id pk=unit.id %}" class="{% if sidebar.unit == unit %}sidebar__units__active{% endif %}">
                       {{ unit.lesson.title }}
                     </a>
                   </li>
@@ -145,14 +145,14 @@
               <li>
                 <!-- TODO: This should always be visible if the user has a courselet in the active course and this if should not be necessary -->
                 {% if sidebar.courslet %}
-                  <a href="{% url 'ctms:unit_create' course_pk=sidebar.course.id courslet_pk=sidebar.courslet.id %}" class="sidebar__add">Add Unit</a>
+                  <a href="{% url 'ctms:unit_create' course_pk=sidebar.courslet.course.id courslet_pk=sidebar.courslet.id %}" class="sidebar__add">Add Unit</a>
                 {% endif %}
               </li>
 
               {% if sidebar.courslet %}
               <li>
                 <!-- TODO: Add link to add units by chat -->
-                <a href="{% url 'ctms:add_units_chat' course_pk=sidebar.course.id pk=sidebar.courslet.id %}" class="sidebar__add">Add Units by Chat</a>
+                <a href="{% url 'ctms:add_units_chat' course_pk=sidebar.courslet.course.id pk=sidebar.courslet.id %}" class="sidebar__add">Add Units by Chat</a>
               </li>
               {% endif %}
             </ul>
@@ -162,3 +162,11 @@
     {% endif %}
   </div>
 </aside>
+
+{% if sidebar.DEBUG %}
+<div class="debug page">
+  {#% debug %#}
+  {{ sidebar|pprint }}
+  {#% debug %#}
+</div>
+{% endif %}


### PR DESCRIPTION
fix(sidebar_middleware): Fixed logic related to remembering Course/Courselet/Unit ids in sidebar MW

Changes in sidebar templates to make URLs (Courselet) more consistent
Small fix in ctms/views.py