### PR TITLE
[ISSUE-554] The 'smthng went wrong' error appears when open courselet which just has been created

### DIFF
--- a/mysite/chat/urls.py
+++ b/mysite/chat/urls.py
@@ -21,9 +21,15 @@ urlpatterns = patterns(
     '',
     url(r'^ui/$', TemplateView.as_view(template_name="cui/index.html")),
     url(
-        r'^enrollcode/(?P<enroll_key>[a-zA-Z0-9]+)/0/?$',
+        r'^enrollcode/(?P<enroll_key>[a-zA-Z0-9]+)/(?P<chat_id>0)/?$',
         InitNewChat.as_view(),
         name='init_chat_api'
+    ),
+
+    url(
+        r'^enrollcode/(?P<enroll_key>[a-zA-Z0-9]+)/(?P<chat_id>\d+)/history/?$',
+        ChatInitialViewFSM.as_view(template_name='chat/chat_history.html'),
+        name='courselet_history'
     ),
     url(
         r'^enrollcode/(?P<enroll_key>[a-zA-Z0-9]+)/(?P<chat_id>\d+)?/?$',

--- a/mysite/chat/views.py
+++ b/mysite/chat/views.py
@@ -31,6 +31,7 @@ class ChatInitialView(LoginRequiredMixin, View):
     Entry point for Chat UI.
     """
     next_handler = injections.depends(ProgressHandler)
+    template_name = 'chat/main_view.html'
 
     def get_enroll_code_object(self, enroll_key):
         """
@@ -225,7 +226,7 @@ class ChatInitialView(LoginRequiredMixin, View):
 
         return render(
             request,
-            'chat/main_view.html',
+            self.template_name,
             {
                 'chat_sessions': chat_sessions, #.exclude(id=chat.id), # TODO: UNCOMMENT this line to exclude current chat from sessions
                 'chat': chat,

--- a/mysite/templates/chat/chat_history.html
+++ b/mysite/templates/chat/chat_history.html
@@ -99,53 +99,10 @@
         </div>
 
         <div class="cta">
-
-          <section id="chat-sessions" class="chat-sessions-list">
-            <div class="container">
-              <div class="row">
-                <div class="col-lg-8 col-lg-offset-2">
-                  <h3>
-                    My History
-                  </h3>
-                  <p class="history-description">
-                    Click on a chat session to continue working on it or to review your previous answers.
-                    You can start over if you want work on the lessons in this courselet again by clicking on
-                    <i>New Chat Session</i> below.
-                  </p>
-
-                  <ul>
-                    {% if chat_sessions %}
-                      {% for chat_sess in chat_sessions %}
-                        <li>
-                          <a href="{{ domain }}/chat/enrollcode/{{ chat_sess.enroll_code.enrollCode }}/{{ chat_sess.id }}/" data-chat-id="{{ chat_sess.id }}" class="chat-start">
-                            <h4>{{ chat_sess.timestamp|date:"F j, Y P" }}</h4>
-                            <p>{{ chat_sess.lessons_done }} of {{ chat_sess.total_lessons }} lessons done</p>
-                            <p>Time spent: {{ chat_sess.get_formatted_time_spent }} </p>
-                            <div class="course-content-unit-progress">
-                              <span style="width: {% if chat_sess %}{{ chat_sess.progress }}{% else %}0{% endif %}%;;"></span>
-                            </div>
-                          </a>
-                        </li>
-                      {% endfor %}
-                    {% endif %}
-                    <li>
-                      <a class="start-new-session chat-start" href="{{ domain }}/chat/enrollcode/{{ chat.enroll_code.enrollCode }}/0/" data-chat-id="0">
-                        <h4>New Chat Session</h4>
-                      </a>
-                    </li>
-                  </ul>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          {% comment %}
           <div class="container">
             <button class="chat-start">
               {% if fsmstate %}Let's Get Started!{% else %}View History{%endif%}</button>
           </div>
-          {% endcomment %}
-
         </div>
       </div>
 
@@ -231,7 +188,6 @@
     var CUI = CUI || {};
     CUI.config = CUI.config || {};
 
-    CUI.config.initNewChatUrl = '{% url 'chat:init_chat_api' enroll_key=enroll_code chat_id=0 %}';
     CUI.config.chatID = {{ chat_id }};
     CUI.config.historyUrl = '/chat/history/';
     CUI.config.progressUrl = '/chat/progress/';

--- a/mysite/templates/lms/course_page.html
+++ b/mysite/templates/lms/course_page.html
@@ -87,7 +87,7 @@
                 {% if courslet_history %}
                   {% for chat in courslet_history %}
                     <li>
-                      <a href="{{ domain }}/chat/enrollcode/{{ chat.enroll_code.enrollCode }}/{{ chat.id }}">
+                      <a href="{{ domain }}{% url 'chat:courselet_history' enroll_key=chat.enroll_code.enrollCode chat_id=chat.id %}">
                         <h3>{{ chat.get_course_unit.unit.title }}</h3>
                         <h3>{{ chat.last_modify_timestamp|date:"F j, Y P" }}</h3>
 


### PR DESCRIPTION
[ISSUE-554](https://github.com/cjlee112/socraticqs2/issues/554)

Issue
===
When user open chat history we should show different HTML.

Solution
===
Added new template for view chat history