### PR TITLE
[issue #549] Fix error appears when trying to open finished courselet

### DIFF
--- a/mysite/chat/models.py
+++ b/mysite/chat/models.py
@@ -110,7 +110,7 @@ class Chat(models.Model):
         :return: datetime.timedelta
         '''
         if not self.last_modify_timestamp:
-            last_msg = self.message_set.all().order_by('-timestamp').first()
+            last_msg = self.message_set.filter(timestamp__isnull=False).order_by('-timestamp').first()
             if last_msg:
                 self.last_modify_timestamp = last_msg.timestamp
                 self.save()


### PR DESCRIPTION
## Fix for issue #549 

## This PR fix error appears when trying to open finished courselet


If chat has no last_modify_timestamp we should get last message and assign it's timestamp to this field.  Messageges should be filtered out to not include messages with timestamp NULL.