### PR TITLE
[ISSUE #512]: now when user add units by chat he will see steps (questions) in sidebar

### DIFF
--- a/mysite/chat/fsm_plugin/chat_add_lesson.py
+++ b/mysite/chat/fsm_plugin/chat_add_lesson.py
@@ -26,6 +26,17 @@ def want_to_continue(self, edge, fsmStack, request, useCurrent=False, **kwargs):
 
 class START(object):
     path = 'fsm:fsm_node'
+    title = 'Start creating new unit in the courselet'
+    help = ''
+    edges = (
+        dict(name='next', toNode='UNIT_NAME_TITLE', title='next',
+             description='',
+             showOption=True),
+    )
+
+
+class UNIT_NAME_TITLE(object):
+    path = 'fsm:fsm_node'
     title = 'Name your unit'
     help = 'Input unit title'
     edges = (
@@ -33,7 +44,6 @@ class START(object):
              description='',
              showOption=True),
     )
-
 
 class GET_UNIT_NAME_TITLE(object):
     path = 'fsm:fsm_node'
@@ -133,7 +143,7 @@ def get_specs():
         description='''Guides you through the steps of adding a new
                     lesson to this courselet''',
         pluginNodes=[
-            START, GET_UNIT_NAME_TITLE, UNIT_QUESTION, GET_UNIT_QUESTION, HAS_UNIT_ANSWER, GET_HAS_UNIT_ANSWER,
+            START, UNIT_NAME_TITLE, GET_UNIT_NAME_TITLE, UNIT_QUESTION, GET_UNIT_QUESTION, HAS_UNIT_ANSWER, GET_HAS_UNIT_ANSWER,
             GET_UNIT_ANSWER, UNIT_ANSWER, WELL_DONE, END
         ],
         fsmGroups=('teach/unit_tasks',),

--- a/mysite/chat/models.py
+++ b/mysite/chat/models.py
@@ -233,10 +233,7 @@ class Message(models.Model):
         # return html.split("\n")[0]
         p = re.compile(r'<.*?>')
 
-        if not self.text:
-            raw_html = self.content.text
-        else:
-            raw_html = self.text
+        raw_html = self.text or self.content.text
 
         raw_html = raw_html.split("\n")[0]
         html = mark_safe(md2html(raw_html))

--- a/mysite/chat/models.py
+++ b/mysite/chat/models.py
@@ -1,3 +1,4 @@
+import re
 from uuid import uuid4
 import datetime
 
@@ -224,10 +225,31 @@ class Message(models.Model):
     def is_in_fsm_node(self, node_name):
         return self.chat.state and self.chat.state.fsmNode.fsm.name == node_name
 
+    def get_sidebar_html(self):
+        '''
+        :return: Return stripped html text (ho html tags)
+        '''
+        # html = self.get_html()
+        # return html.split("\n")[0]
+        p = re.compile(r'<.*?>')
+
+        if not self.text:
+            raw_html = self.content.text
+        else:
+            raw_html = self.text
+
+        raw_html = raw_html.split("\n")[0]
+        html = mark_safe(md2html(raw_html))
+        stripped_text = p.sub('', html)
+        return stripped_text
+
     def get_html(self):
         html = self.text
         if self.is_in_fsm_node('chat_add_lesson'):
-            return mark_safe(md2html(self.text or ''))
+            if self.contenttype == 'chatdivider':
+                html = self.content.text
+            else:
+                return mark_safe(md2html(self.text or ''))
         if self.content_id:
             if self.contenttype == 'chatdivider':
                 html = self.content.text

--- a/mysite/chat/serializers.py
+++ b/mysite/chat/serializers.py
@@ -283,7 +283,8 @@ class ChatProgressSerializer(serializers.ModelSerializer):
 
 class AddUnitByChatStepSerializer(serializers.ModelSerializer):
     """
-    Serializer for Message, used when user in "Add unit by chat" chat to serialize messages for Progress
+    Serializer for Message, used when user in "Add unit by chat"
+    chat to serialize messages for Progress
     """
     html = serializers.CharField(source='get_sidebar_html', read_only=True)
     isDone = serializers.SerializerMethodField()

--- a/mysite/chat/urls.py
+++ b/mysite/chat/urls.py
@@ -2,6 +2,7 @@ import injections
 from django.conf.urls import patterns, url, include
 from django.views.generic import TemplateView
 from rest_framework.routers import SimpleRouter
+from chat.api import AddUnitByChatProgressView
 
 from chat.views import CourseletPreviewView, ChatAddLessonView, TestChatInitialView
 from .views import ChatInitialView, InitializeLiveSession
@@ -46,6 +47,8 @@ urlpatterns = patterns(
     ),
     url(r'^history/$', HistoryView.as_view(), name='history'),
     url(r'^progress/$', ProgressView.as_view(), name='progress'),
+    url(r'^progress/add_unit/$', AddUnitByChatProgressView.as_view(), name='add_unit_progress'),
+
 
     url(r'^initLiveSession/(?P<state_id>\d+)/$',
         InitializeLiveSession.as_view(), name="init_live_chat"),

--- a/mysite/fsm/mixins.py
+++ b/mysite/fsm/mixins.py
@@ -365,7 +365,7 @@ class ChatMixin(object):
                             owner=chat.user,
                             kind='button',
                             is_additional=is_additional)
-        if self.name == 'DIVIDER':
+        if self.name == 'DIVIDER' or (self.name == 'START' and self.is_chat_add_lesson()):
             divider = ChatDivider(text=self.title)
             divider.save()
             message = Message.objects.get_or_create(
@@ -414,7 +414,7 @@ class ChatMixin(object):
             # content_id = current.id if current else None
             message = Message.objects.create(**_data)
 
-        if self.name in ('START', 'NOT_A_QUESTION') and self.is_chat_add_lesson():
+        if self.name in ('UNIT_NAME_TITLE', 'NOT_A_QUESTION') and self.is_chat_add_lesson():
             text = "**{}** \n\n{}".format(self.title, getattr(self, 'help', '') or '')
             _data = dict(
                 chat=chat,

--- a/mysite/templates/chat/add_unit_chat.html
+++ b/mysite/templates/chat/add_unit_chat.html
@@ -189,7 +189,7 @@
 
     CUI.config.chatID = {{ chat_id }};
     CUI.config.historyUrl = '/chat/history/';
-    CUI.config.progressUrl = '/chat/progress/';
+    CUI.config.progressUrl = '{% url 'chat:add_unit_progress' %}';
     CUI.config.resourcesUrl = '/chat/resources/';
     CUI.config.courseUnit = '{{ unit.id }}';
     CUI.config.course = '{{ course.id }}';


### PR DESCRIPTION
### This PR fix issue described in #512 - Sidebar is empty

### Changes done to solve it
* Adds new node in chat_add_lesson FSM - UNIT_NAME_TITLE
* Changes in mixins to show DIVIDER when user in START node
* Adds new method in Message model to get html for sidebar
* Adds new chat url for progress (only for add unit by chat) and handler for progress
* Adds 2 serializers - for progress and for message to serialize it to breakpoint