### PR TITLE
chat initialization process moved to JS

### DIFF
--- a/mysite/chat/models.py
+++ b/mysite/chat/models.py
@@ -203,15 +203,17 @@ class Message(models.Model):
         )
 
     def should_ask_confidence(self):
-        return 'CONFIDENCE' in [
-            i['name']
-            for i in self.chat.state.fsmNode.fsm.fsmnode_set.all().values('name')
-        ]
+        if self.chat.state:
+            return 'CONFIDENCE' in [
+                i['name']
+                for i in self.chat.state.fsmNode.fsm.fsmnode_set.all().values('name')
+            ]
+        return False
 
     def get_options(self):
         options = None
         if (
-            self.chat and self.chat.next_point and
+            self.chat and self.chat.state and self.chat.next_point and
             self.chat.next_point.input_type == 'options'
         ):
             if self.chat.next_point.kind == 'button':

--- a/mysite/chat/views.py
+++ b/mysite/chat/views.py
@@ -81,6 +81,19 @@ class ChatInitialView(LoginRequiredMixin, View):
         return will_learn, need_to_know
 
     def get_or_init_chat(self, enroll_code, chat_id):
+        '''Gets chat by id following these steps:
+         * try to cast recieved ID to int
+         * if gets an error while casting:
+           * set i_chat_id = 0 if ValueError
+           * set i_chat_id = None if TypeError
+         * if i_chat_id:
+           * try to get chat by id
+         * if i_chat_id is None:
+           * restore last session
+         * if i_chat_id == 0:
+           * create new chat
+        :return i_chat_id and chat
+        '''
         courseUnit = enroll_code.courseUnit
         try:
             # try to convert chat_id to int
@@ -104,13 +117,6 @@ class ChatInitialView(LoginRequiredMixin, View):
                 user=self.request.user,
                 state__isnull=False
             ).first()
-            if not chat and enroll_code:  # no last session - create new one
-                chat = Chat(
-                    user=self.request.user,
-                    enroll_code=enroll_code,
-                    instructor=courseUnit.course.addedBy
-                )
-                chat.save()
         elif i_chat_id == 0 and enroll_code:  # create new session
             chat = Chat(
                 user=self.request.user,
@@ -119,15 +125,7 @@ class ChatInitialView(LoginRequiredMixin, View):
             )
             chat.save()
 
-        if chat.message_set.count() == 0:
-            next_point = self.next_handler.start_point(unit=courseUnit.unit, chat=chat, request=self.request)
-        elif not chat.state:
-            next_point = None
-            chat.next_point = next_point
-            chat.save()
-        else:
-            next_point = chat.next_point
-        return chat, next_point
+        return chat, i_chat_id
 
     def get(self, request, enroll_key, chat_id=None):
         enroll_code = self.get_enroll_code_object(enroll_key)
@@ -161,9 +159,11 @@ class ChatInitialView(LoginRequiredMixin, View):
             enrolling.role = Role.ENROLLED
             enrolling.save()
 
-        chat, next_point = self.get_or_init_chat(enroll_code, chat_id)
+        # new chat will be created only if chat_id is 0
+        chat, i_chat_id = self.get_or_init_chat(enroll_code, chat_id)
+        lessons = unit.get_exercises()
 
-        if chat.is_live:
+        if chat and chat.is_live:
             lessons = Message.objects.filter(
                 chat=chat,
                 contenttype='unitlesson',
@@ -171,8 +171,6 @@ class ChatInitialView(LoginRequiredMixin, View):
                 type='message',
                 owner=request.user,
             )
-        else:
-            lessons = unit.get_exercises()
 
         will_learn, need_to_know = self.get_will_learn_need_know(unit, courseUnit)
 
@@ -230,7 +228,7 @@ class ChatInitialView(LoginRequiredMixin, View):
             {
                 'chat_sessions': chat_sessions, #.exclude(id=chat.id), # TODO: UNCOMMENT this line to exclude current chat from sessions
                 'chat': chat,
-                'chat_id': chat.id,
+                'chat_id': i_chat_id,
                 'course': courseUnit.course,
                 'instructor_icon': instructor_icon,
                 'unit': unit,
@@ -241,8 +239,7 @@ class ChatInitialView(LoginRequiredMixin, View):
                 'lessons': lessons,
                 'lesson_cnt': len(lessons),
                 'duration': len(lessons) * 3,
-                'next_point': next_point,
-                'fsmstate': chat.state,
+                'fsmstate': chat.state if chat else None,
                 'enroll_code': enroll_key,
             }
         )

--- a/mysite/lms/tests.py
+++ b/mysite/lms/tests.py
@@ -120,3 +120,190 @@ class TestCourseView(TestCase):
         self.assertEqual(response.context['livesessions'][0].get_formatted_time_spent(), '1 day, 1:00:00')
 
 
+class TestCourseletViewHistoryTab(TestCase):
+
+    def setUp(self):
+        self.user = User.objects.create_user(username='test', password='test')
+        self.client.login(username='test', password='test')
+
+        self.course = Course(title='test_title', addedBy=self.user)
+        self.course.save()
+        self.unit = Unit(title='test unit title', addedBy=self.user)
+        self.unit.save()
+        self.course_unit = CourseUnit(
+            course=self.course,
+            unit=self.unit,
+            order=0,
+            addedBy=self.user
+        )
+        self.course_unit.releaseTime = timezone.now() - datetime.timedelta(days=1)
+        self.course_unit.save()
+
+        self.enroll = EnrollUnitCode(courseUnit=self.course_unit)
+        self.enroll.save()
+
+        self.role = Role(course=self.course, user=self.user, role=Role.INSTRUCTOR)
+        self.role.save()
+
+        self.student_role = Role(course=self.course, user=self.user, role=Role.ENROLLED)
+        self.student_role.save()
+
+        self.concept = Concept.new_concept('bad', 'idea', self.unit, self.user)
+
+        self.lesson = Lesson(
+            title='New York Test Lesson',
+            text='brr',
+            addedBy=self.user,
+            kind=Lesson.ORCT_QUESTION
+        )
+        self.lesson.save_root(self.concept)
+
+        self.unit_lesson = UnitLesson(
+            unit=self.unit,
+            lesson=self.lesson,
+            addedBy=self.user,
+            treeID=self.lesson.id,
+            order=0
+        )
+        self.unit_lesson.save()
+
+        self.unit_lesson_answer = UnitLesson(
+            parent=self.unit_lesson,
+            unit=self.unit,
+            lesson=self.lesson,
+            addedBy=self.user,
+            treeID=self.lesson.id,
+            kind=UnitLesson.ANSWERS
+        )
+        self.unit_lesson_answer.save()
+
+        self.user = User.objects.create_user(username='admin', password='admin')
+
+        call_command('fsm_deploy')
+
+    def test_click_on_courslet_creates_new_chat(self):
+        # test that there's no history yet
+        response = self.client.get(
+            reverse('lms:course_view', kwargs={'course_id': self.course.id})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(list(response.context['courslets']))
+
+        self.assertEqual(response.status_code, 200)
+
+        chats_count_1 = Chat.objects.all().count()
+
+        # firstly call to chat:init_chat_api function with enroll_key and chat_id=0
+        response = self.client.get(
+            reverse(
+                'chat:init_chat_api',
+                kwargs={
+                    'enroll_key': self.enroll.enrollCode,
+                    'chat_id': 0
+                }
+            ),
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        json_content = json.loads(response.content)
+        chat_id = json_content['id']
+
+        response = self.client.get(
+            reverse('chat:chat_enroll', kwargs={'enroll_key': self.enroll.enrollCode, 'chat_id': chat_id})
+        )
+        self.assertEqual(response.context['chat'].id, Chat.objects.all().first().id)
+        self.assertEqual(response.status_code, 200)
+        chats_count_2 = Chat.objects.count()
+
+        self.assertNotEqual(chats_count_2, chats_count_1)
+
+        response = self.client.get(
+            reverse('chat:chat_enroll', kwargs={'enroll_key': self.enroll.enrollCode, 'chat_id': chat_id})
+        )
+        chats_count_3 = Chat.objects.count()
+
+        response = self.client.get(
+            reverse('chat:chat_enroll', kwargs={'enroll_key': self.enroll.enrollCode, 'chat_id': chat_id})
+        )
+        chats_count_4 = Chat.objects.count()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(chats_count_4, chats_count_2)
+        self.assertEqual(chats_count_3, chats_count_2)
+
+        self.assertEqual(response.context['chat'].id, Chat.objects.all().first().id)
+
+        chat = Chat.objects.all().first()
+        # get chat and set state to None it means that courslet finished.
+        chat.state = None
+        chat.save()
+
+        response = self.client.get(
+            reverse('lms:course_view', kwargs={'course_id': self.course.id})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Chat.objects.count(), chats_count_2)
+        self.assertEqual(len(list(response.context['courslets'])), 1)
+
+    def test_courslet_history(self):
+        enroll_code = EnrollUnitCode.get_code(self.course_unit)
+
+        response = self.client.get(
+            reverse(
+                'chat:init_chat_api',
+                kwargs={
+                    'enroll_key': self.enroll.enrollCode,
+                    'chat_id': 0
+                }
+            ),
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        json_content = json.loads(response.content)
+        chat_id = json_content['id']
+
+        response = self.client.get(
+            reverse('chat:chat_enroll', args=(enroll_code, chat_id)), follow=True
+        )
+
+        response = self.client.get(
+            reverse('chat:history'), {'chat_id': chat_id}, follow=True
+        )
+        json_content = json.loads(response.content)
+
+        next_url = json_content['input']['url']
+
+        answer = 'My Answer'
+        response = self.client.put(
+            next_url,
+            data=json.dumps({"text": answer, "chat_id": chat_id}),
+            content_type='application/json',
+            follow=True
+        )
+
+        json_content = json.loads(response.content)
+        next_url = json_content['input']['url']
+
+        response = self.client.get(
+            next_url, {'chat_id': chat_id}, follow=True
+        )
+
+        json_content = json.loads(response.content)
+        next_url = json_content['input']['url']
+
+        self.assertIsNotNone(json_content['input']['options'])
+        self.assertEquals(len(json_content['addMessages']), 2)
+
+        # emulate chat finished - set state to None
+
+        Chat.objects.filter(id=chat_id).update(state=None)
+
+        response = self.client.get(
+            reverse('chat:chat_enroll', args=(enroll_code, chat_id)), follow=True
+        )
+        response = self.client.get(
+            reverse('chat:history'), {'chat_id': chat_id}, follow=True
+        )
+        json_content = json.loads(response.content)
+
+        self.assertIsNone(json_content['input']['options'])
+        self.assertEquals(len(json_content['addMessages']), 4)
+
+

--- a/mysite/templates/chat/main_view.html
+++ b/mysite/templates/chat/main_view.html
@@ -233,10 +233,10 @@
     CUI.config = CUI.config || {};
 
     {% if not fsmstate.isLiveSession %}
-    CUI.config.initNewChatUrl = '{% url 'chat:init_chat_api' enroll_key=chat.enroll_code.enrollCode chat_id=0 %}';
+    CUI.config.initNewChatUrl = '{% url 'chat:init_chat_api' enroll_key=enroll_code chat_id=0 %}';
     {% endif %}
 
-    CUI.config.chatID = {{ chat_id }};
+    CUI.config.chatID = {% if chat_id %}{{ chat_id }}{% else %}0{% endif %};
     CUI.config.historyUrl = '/chat/history/';
     CUI.config.progressUrl = '/chat/progress/';
     CUI.config.resourcesUrl = '/chat/resources/';


### PR DESCRIPTION
### This ticket is solve a problem describe in #557 

### Solution:
Now when user load page chat_enroll it will not create new chat. New chat will be created only after JS ajax request to api endpoint. This endpoint will create new chat and start FSM.

It's first version of implementation, next I will remove all comments. I need them now to understand what changes I've done