### PR TITLE
[ISSUE #575] Fix courselet progress when user start new live session (progress of courselet come to be full).

### DIFF
--- a/mysite/lms/views.py
+++ b/mysite/lms/views.py
@@ -38,7 +38,8 @@ class CourseView(View):
                 'chat': Chat.objects.filter(
                     enroll_code__courseUnit=courselet,
                     user=request.user,
-                    state__isnull=False
+                    state__isnull=False,
+                    is_live=False
                 ).first()
             }
             for courselet in course.get_course_units(True)


### PR DESCRIPTION
### [ ISSUE #575 ] The progress bar shows incorrect progress after leaving live session 

### Solution:
When filter courselet's chats in lms/views.py:CourseView is_live parameter must be False.