### PR TITLE
[ISSUE 572]: Added md2html into FaqItemPlugin HTML

### DIFF
--- a/mysite/templates/pages/faq_item_plugin.html
+++ b/mysite/templates/pages/faq_item_plugin.html
@@ -1,8 +1,10 @@
+{% load ct_extras %}
+
 {% if not instance.hidden %}
 <div>
-<dt>Q: {{ instance.question }}</dt>
+<dt>Q: {{ instance.question|md2html }}</dt>
 <br>
-<dd>A: {{ instance.answer }}</dd>
+<dd>A: {{ instance.answer|md2html }}</dd>
 <hr>
 </div>
 {% endif %}


### PR DESCRIPTION
### FIX FOR ISSUE #572

### SOLUTION:
Added md2html into django cms FAQ plugin HTML