### PR TITLE
fix(issue#585): Don't need to show "New Chat Session" when view history.

### DIFF
--- a/mysite/chat/views.py
+++ b/mysite/chat/views.py
@@ -186,8 +186,8 @@ class ChatInitialView(LoginRequiredMixin, View):
             enroll_code=enroll_code,
             user=request.user,
             instructor=courseUnit.course.addedBy,
-            state__isnull=False
-        )
+            is_live=False
+        ).order_by('-state')
         # ).annotate(
         #     lessons_done=models.Sum(
         #         models.Case(

--- a/mysite/templates/chat/main_view.html
+++ b/mysite/templates/chat/main_view.html
@@ -100,7 +100,7 @@
 
         <div class="cta">
 
-          {% if not fsmstate.isLiveSession %}
+          {% if not chat_id %}
           <section id="chat-sessions" class="chat-sessions-list">
             <div class="container">
               <div class="row">
@@ -140,7 +140,7 @@
             </div>
           </section>
 
-          {% elif fsmstate.isLiveSession %}
+          {% elif chat_id %}
           <div class="container">
             <button class="chat-start">
               {% if fsmstate %}Let's Get Started!{% else %}View History{%endif%}</button>


### PR DESCRIPTION
### PROBLEM:
Is described in ticket #585 

### SOLUTION:
If chat_id is present in template context and it's not None (not empty, not zero etc) - if fsmstate is not empty show button "Lets get started", if fsmstate is empty (not present in context) show button "View history".
If no chat_id in context - show chat sessions and "create new chat session" button.