### PR TITLE
fix(issue#618): Changes in showing search results of error models. Show them as UL with 'Versions' button

### DIFF
--- a/mysite/templates/ct/errors.html
+++ b/mysite/templates/ct/errors.html
@@ -104,29 +104,99 @@ $( "#noverrtoggle" ).click(function() {
 </form>
 {% endif %}
 
-{% if lessonSet %}
+{% if found_lessons %}
 <h2>Search Results</h2>
 If one of these is relevant to this concept,
 please click <b>{{ actionLabel }}</b>.
 <table class="table table-striped">
 <thead><tr>
-  <th>Error</th>
+  <th>Error</th><th></th><th>Type</th><th>Author</th>
 </tr></thead>
 <tbody>
-{% for ul in lessonSet %}
-  <tr><td>
-  <a href="{{ actionTarget |get_object_url:ul }}">{{ ul.lesson.title }}</a>
-  <form action="{{ actionTarget }}" method="post"
-   style=" display:inline!important;">
-  {% csrf_token %}
-  <input type="hidden" name="ulID" value="{{ ul.pk }}" />
-  <input type="submit" value="{{ actionLabel }}" />
-  </form>
-  </td></tr>
+{% for tree, branch in found_lessons.items %}
+    {% if branch %}
+        <tr><td colspan="4">
+        {{ tree.lesson.title }} &nbsp;
+    <a role="button" data-toggle="collapse" class="btn btn-default" href="#{{ tree.id }}" aria-expanded="false" aria-controls="{{ tree.id }}">
+        Versions
+         </a>
+        <div class="collapse" id="{{ tree.id }}">
+            <table class="table table-striped">
+                <thead>
+                    <th>Error</th><th>Branch</th><th>Author</th><th>Commit message</th><th></th><th>Commit time</th><th>Type</th>
+                </thead>
+                <tr>
+                  <td>
+                    <a href="{{ actionTarget|get_object_url:tree }}">{{ tree.lesson.title }}</a>
+                  </td>
+                  <td>{{ tree.branch }}</td>
+                  {% with tree.lesson.addedBy.get_full_name as full_name %}
+                  {% if full_name %}
+                  <td>{{ full_name }}</td>
+                  {% else %}
+                  <td>{{ tree.lesson.addedBy.username }}</td>
+                  {% endif %}
+                  {% endwith %}
+                  <td>{{ tree.lesson.changeLog }}</td>
+                  <td>
+                  <form action="{{ actionTarget }}" method="post"
+                   style=" display:inline!important;" class="pull-right">
+                  {% csrf_token %}
+                  <input type="hidden" name="ulID" value="{{ tree.pk }}" />
+                  <input type="submit" value="{{ actionLabel }}" />
+                  </form>
+                  </td>
+                  <td>{{ tree.lesson.commitTime }}</td>
+                <td>{{ tree.lesson.get_kind_display }}</td>
+               </tr>
+               {% for unit_lesson in branch %}
+                  <tr>
+                  <td>
+                  <a href="{{ actionTarget|get_object_url:unit_lesson }}">{{ unit_lesson.lesson.title }}</a></td>
+                  <td>{{ unit_lesson.branch }}</td>
+                  {% with unit_lesson.lesson.addedBy.get_full_name as full_name %}
+                  {% if full_name %}
+                  <td>{{ full_name }}</td>
+                  {% else %}
+                  <td>{{ unit_lesson.lesson.addedBy.username }}</td>
+                  {% endif %}
+                  {% endwith %}
+                  <td>{{ unit_lesson.lesson.changeLog }}</td>
+                  <td>
+                  <form action="{{ actionTarget }}" method="post"
+                   style=" display:inline!important;" class="pull-right">
+                  {% csrf_token %}
+                  <input type="hidden" name="ulID" value="{{ unit_lesson.pk }}" />
+                  <input type="submit" value="{{ actionLabel }}" />
+                  </form>
+                  </td>
+                  <td>{{ unit_lesson.lesson.commitTime }}</td>
+                  <td>{{ unit_lesson.lesson.get_kind_display }}</td>
+               </tr>
+               {% endfor %}
+            </table>
+        </div>
+        </tr>
+    {% else %}
+         <tr><td>
+          <a href="{{ actionTarget |get_object_url:tree }}">{{ tree.lesson.title }}</a>
+             </td><td>
+          <form action="{{ actionTarget }}" method="post"
+           style=" display:inline!important;" class="pull-right">
+          {% csrf_token %}
+          <input type="hidden" name="ulID" value="{{ tree.pk }}" />
+          <input type="submit" value="{{ actionLabel }}" />
+          </form>
+          </td>
+            <td>{{ tree.lesson.get_kind_display }}</td>
+            <td>{{ tree.lesson.addedBy.get_full_name }}</td>
+          </tr>
+    {% endif %}
 {% endfor %}
 </tbody>
 </table>
 {% endif %}
+
 
 {% if lessonForm %}
 <h3>Write a New Error Model</h3>


### PR DESCRIPTION
### [ISSUE #618] 

The problem is described here #618

### [SOLUTION] 

Rework error models search template to show EM like we do it for UL, if they have the same treeID we wrap them up and show button Versions.