### PR TITLE
fix(issue#621): Fix to handle case when Concept doesn't have associated UnitLesson. (Not as part of Unit but as ErrorModel or so)

### DIFF
--- a/mysite/ct/tests/models.py
+++ b/mysite/ct/tests/models.py
@@ -140,6 +140,17 @@ class ConceptTest(TestCase):
         self.assertEqual(result[0].kind, UnitLesson.MISUNDERSTANDS)
         self.assertEqual(result[0].parent, self.unit_lesson)
 
+    def test_get_url_no_ul_error(self):
+        # if no UnitLesson associated with Concept it should return '#'
+        UnitLesson.objects.filter(lesson__concept=self.concept).delete()
+        self.concept.isError = True
+        base_path = reverse('ct:study_unit', args=(self.course.id, self.unit.id))
+        result = self.concept.get_url(base_path)
+        self.assertEqual(
+            result,
+            '#'
+        )
+
     def test_get_url(self):
         base_path = reverse('ct:study_unit', args=(self.course.id, self.unit.id))
         result = self.concept.get_url(base_path)


### PR DESCRIPTION
### [ISSUE #621] The problem is described here #621 
When someone deleted UnitLesson associated with error model from concept, it returns 500 error.

### [SOLUTION] 
Wrap method Concept.get_url with try\except. In usual way it will return path, as desired, in case of exception (if no UL associated with Concept) it will return '#' to avoid of crashing the whole page. 
