### PR TITLE
fix(issue#687): Fix for issue #687 to avoid incorrect timezone in user profile.

### DIFF
--- a/mysite/accounts/models.py
+++ b/mysite/accounts/models.py
@@ -4,6 +4,11 @@ import pygeoip
 from django.db import models
 from django.contrib.auth.models import User
 from django.conf import settings
+import pytz
+
+ALL_TIMEZONES_CHOICES = [
+    (i, i) for i in pytz.all_timezones
+]
 
 
 class Profile(models.Model):
@@ -14,7 +19,7 @@ class Profile(models.Model):
      - `timezone` - offset from UTC-0
     """
     user = models.OneToOneField(User)
-    timezone = models.CharField(max_length=255, blank=True, null=True)
+    timezone = models.CharField(max_length=255, blank=True, null=True, choices=ALL_TIMEZONES_CHOICES)
 
     @staticmethod
     def get_user_ip(request):

--- a/mysite/analytics/tasks.py
+++ b/mysite/analytics/tasks.py
@@ -1,4 +1,5 @@
 import pytz
+from pytz.exceptions import UnknownTimeZoneError
 from accounts.models import Profile
 from mysite.celery import app
 
@@ -65,9 +66,13 @@ def report(course_id, user_id):
         except Profile.DoesNotExist:
             u_tz = settings.TIME_ZONE
 
-        localized_ts = submit_time.astimezone(
-            pytz.timezone(u_tz)
-        ).strftime("%d-%m-%Y-%H:%M:%SZ%z")
+        try:
+            user_tz = pytz.timezone(u_tz)
+        except UnknownTimeZoneError as e:
+            user_tz = pytz.timezone(settings.TIME_ZONE)
+            print("User has incorrect time zone in Profile. Will use default TZ.")
+
+        localized_ts = submit_time.astimezone(user_tz).strftime("%d-%m-%Y-%H:%M:%SZ%z")
 
         r = dict(
           id=_id,


### PR DESCRIPTION
## Fix for issue #687 to avoid incorrect timezone in user profile.

### Problem 
is described here #687 

### Solution
Now field timezone has choices with all avialable timezones, and in case for old profiles with already set incorrect tz it will use default TZ from settings file.