### PR TITLE
fix(issue#686): When user login through lti we create profile (if not exist) and store tz

### DIFF
--- a/mysite/accounts/models.py
+++ b/mysite/accounts/models.py
@@ -43,7 +43,7 @@ class Profile(models.Model):
         except cls.DoesNotExist:
             profile = cls.objects.create(user=request.user)
 
-        if not profile.timezone:
+        if profile.timezone not in pytz.all_timezones:
             gi = pygeoip.GeoIP(settings.GEO_IP_DB_PATH)
             loc_data = gi.record_by_addr(cls.get_user_ip(request)) or {}
             timezone = loc_data.get('time_zone', settings.TIME_ZONE)

--- a/mysite/accounts/models.py
+++ b/mysite/accounts/models.py
@@ -1,5 +1,6 @@
 from django.db.models.signals import post_save
 import pygeoip
+import pytz
 
 from django.db import models
 from django.contrib.auth.models import User

--- a/mysite/lti/views.py
+++ b/mysite/lti/views.py
@@ -21,6 +21,7 @@ from lti.models import LTIUser, CourseRef, LtiConsumer
 from .outcomes import store_outcome_parameters
 from ct.models import Course, Role, CourseUnit, Unit
 from chat.models import EnrollUnitCode
+from accounts.models import Profile
 
 
 ROLES_MAP = {
@@ -153,6 +154,9 @@ def lti_redirect(request, lti_consumer, course_id=None, unit_id=None):
     if not user.is_linked:
         user.create_links()
     user.login(request)
+
+    # check user timezone and save it if not yet set or set incorrect timezone
+    Profile.check_tz(request)
 
     if not course_id or not Course.objects.filter(id=course_id).exists():
         if course_ref:


### PR DESCRIPTION
### Problem 
is described here #686 

### Solution
When user log in through lti - get user's location using pygeoip and remember timezon in Profile.timezone